### PR TITLE
Let parent process's stderr pass through to children

### DIFF
--- a/insights_client/__init__.py
+++ b/insights_client/__init__.py
@@ -72,14 +72,10 @@ def run_phase(phase, eggs, inp=None, process_response=True):
         }
         process = subprocess.Popen(insights_command,
                                    preexec_fn=demote(insights_uid, insights_gid, phase),
-                                   stdout=PIPE, stderr=PIPE, stdin=PIPE,
-                                   env=env)
+                                   stdout=PIPE, stdin=PIPE, env=env)
         # stdout is used to communicate with parent process
-        # stderr is used to communicate with end user
         # return code indicates whether or not child process failed
-        stdout, stderr = process.communicate(inp)
-        if stderr:
-            log(stderr.strip())
+        stdout, _ = process.communicate(inp)
         if process.wait() == 0:
             response = process_stdout_response(stdout.strip(), process_response)
             if response is not False:


### PR DESCRIPTION
This enables real time console logging instead of dumping it all at once
after the child process has completed.