### PR TITLE
Properly add legacy redhat-access-insights executable

### DIFF
--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -78,8 +78,6 @@ fi
 if [ -f "/etc/redhat-access-insights/.lastupload" ]; then
 mv /etc/redhat-access-insights/.lastupload /etc/insights-client/.lastupload
 fi
-# Create symlinks to old name
-ln -sf %{_bindir}/insights-client %{_bindir}/redhat-access-insights
 if ! [ -d "/etc/redhat-access-insights" ]; then
 mkdir /etc/redhat-access-insights
 fi
@@ -172,6 +170,7 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 %attr(440,root,root) /etc/insights-client/redhattools.pub.gpg
 
 %attr(755,root,root) %{_bindir}/insights-client
+%attr(755,root,root) %{_bindir}/redhat-access-insights
 %attr(755,root,root) %{_bindir}/insights-client-run
 %attr(755,root,root) /etc/insights-client/insights-client.cron
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
         extras_require={'develop': requires + ['flake8']},
         include_package_data=True,
         entry_points={'console_scripts': [
+            'redhat-access-insights = insights_client:_main',
             'insights-client = insights_client:_main',
             'insights-client-run = insights_client.run:_main'
         ]},


### PR DESCRIPTION
This just adds it as another entry point.  Adding `redhat-access-insights` to the `%files` section tells RPM to not delete the file when uninstalling the old `redhat-access-insights` package.