### PR TITLE
Remove PyYAML RPM dependency

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E501,E126,E127,E128
+ignore = E501,E126,E127,E128,E722
 exclude = bin,docs,include,lib,lib64,.git

--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -23,7 +23,6 @@ Obsoletes: redhat-access-insights
 Requires: python
 Requires: python-setuptools
 Requires: python-requests >= 2.6
-Requires: PyYAML
 Requires: pyOpenSSL
 Requires: libcgroup
 Requires: tar


### PR DESCRIPTION
This can be removed now that the client no longer reads yaml for config.

See https://github.com/RedHatInsights/insights-core/pull/731 as well