### PR TITLE
Add python-six and python-magic RPM dependencies

### DIFF
--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -28,6 +28,8 @@ Requires: libcgroup
 Requires: tar
 Requires: gpg
 Requires: pciutils
+Requires: python-magic
+Requires: python-six
 %if 0%{?rhel} && 0%{?rhel} == 6
 Requires: python-argparse
 %endif


### PR DESCRIPTION
python-six will be required for Python 3 support, and python-magic is
what we want to use for libmagic bindings in RHEL.