### PR TITLE
Use systemd timer instead of cron on RHEL 7 and up

### DIFF
--- a/MANIFEST.rhel6
+++ b/MANIFEST.rhel6
@@ -1,0 +1,11 @@
+include etc/insights-client.spec
+include etc/insights-client.cron
+include etc/insights-client.conf
+include etc/.exp.sed
+include etc/*.pem
+include etc/.fallback.json
+include etc/.fallback.json.asc
+include etc/redhattools.pub.gpg
+include etc/rpm.egg
+include etc/rpm.egg.asc
+include docs/*

--- a/MANIFEST.rhel7
+++ b/MANIFEST.rhel7
@@ -1,5 +1,6 @@
+include etc/insights-client.service
+include etc/insights-client.timer
 include etc/insights-client.spec
-include etc/insights-client.cron
 include etc/insights-client.conf
 include etc/.exp.sed
 include etc/*.pem

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PKGNAME=insights-client
 SRPM=$(RPMTOP)/SRPMS/$(PKGNAME)-*.src.rpm
 TARBALL=$(RPMTOP)/$(PKGNAME)-*.tar.gz
 RPM=$(RPMTOP)/RPMS/noarch/$(PKGNAME)*.rpm
+OS_MAJOR_VER=$(shell python major_version.py)
 PY_SDIST=python setup.py sdist
 
 
@@ -12,7 +13,13 @@ all: rpm
 .PHONY: tarball
 tarball: $(TARBALL)
 $(TARBALL): Makefile
+	if [ "$(OS_MAJOR_VER)" == "6" ]; then\
+		cp MANIFEST.rhel6 MANIFEST.in;\
+	else\
+		cp MANIFEST.rhel7 MANIFEST.in;\
+	fi
 	$(PY_SDIST)
+	rm MANIFEST.in
 
 
 .PHONY: srpm rpm 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PKGNAME=insights-client
 SRPM=$(RPMTOP)/SRPMS/$(PKGNAME)-*.src.rpm
 TARBALL=$(RPMTOP)/$(PKGNAME)-*.tar.gz
 RPM=$(RPMTOP)/RPMS/noarch/$(PKGNAME)*.rpm
-OS_MAJOR_VER=$(shell python major_version.py)
+OS_MAJOR_VER=$(shell python insights_client/major_version.py)
 PY_SDIST=python setup.py sdist
 
 

--- a/etc/insights-client.service
+++ b/etc/insights-client.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Insights Client
+Documentation=man:insights-client(8)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/insights-client --retry 3
+Restart=no
+WatchdogSec=600
+CPUQuota=30%
+MemoryLimit=2G
+TasksMax=20
+BlockIOWeight=100
+ExecStartPost=/bin/bash -c "echo 2G > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.memsw.limit_in_bytes"
+ExecStartPost=/bin/bash -c "echo 1G > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.soft_limit_in_bytes"

--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -96,11 +96,11 @@ if  [ $1 -eq 1  ]; then
     # Symlink new cron job if the old one exists. Remove the old one
     if [ -f "/etc/cron.daily/redhat-access-insights" ]; then
         rm -f /etc/cron.daily/redhat-access-insights
-%if 0%{?rhel} && 0%{?rhel} == 6
-        ln -sf /etc/insights-client/insights-client.cron /etc/cron.daily/insights-client                               
-%else
-        %_bindir/systemctl start insights-client.timer
-%endif
+        %if 0%{?rhel} && 0%{?rhel} == 6
+            ln -sf /etc/insights-client/insights-client.cron /etc/cron.daily/insights-client                               
+        %else
+            %_bindir/systemctl start insights-client.timer
+        %endif
     fi 
 fi
 

--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -28,6 +28,8 @@ Requires: libcgroup
 Requires: tar
 Requires: gpg
 Requires: pciutils
+Requires: python-magic
+Requires: python-six
 %if 0%{?rhel} && 0%{?rhel} == 6
 Requires: python-argparse
 %endif

--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -59,6 +59,11 @@ getent passwd insights > /dev/null || \
     -c "Red Hat Insights" -d /var/lib/insights
 
 %post
+
+%if 0%{?rhel} != 6
+%systemd_post %{name}.timer
+%endif
+
 # Only perform migration from redhat-access-insights to insights-client
 if  [ $1 -eq 1  ]; then
     #Migrate existing machine-id
@@ -93,6 +98,8 @@ if  [ $1 -eq 1  ]; then
         rm -f /etc/cron.daily/redhat-access-insights
 %if 0%{?rhel} && 0%{?rhel} == 6
         ln -sf /etc/insights-client/insights-client.cron /etc/cron.daily/insights-client                               
+%else
+        %_bindir/systemctl start insights-client.timer
 %endif
     fi 
 fi
@@ -140,9 +147,6 @@ setfacl -m g:insights:rw /etc/ansible/facts.d/insights.fact
 setfacl -m g:insights:rw /etc/ansible/facts.d/insights_machine_id.fact
 fi
 
-%if 0%{?rhel} != 6
-%systemd_post %{name}.timer
-%endif
 
 # always perform legacy symlinks
 %posttrans

--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -60,38 +60,38 @@ getent passwd insights > /dev/null || \
 %post
 # Only perform migration from redhat-access-insights to insights-client
 if  [ $1 -eq 1  ]; then
-	#Migrate existing machine-id
-	if  [ -f "/etc/redhat_access_proactive/machine-id" ]; then
-		cp /etc/redhat_access_proactive/machine-id /etc/insights-client/machine-id
-	fi
-	#Migrate OTHER existing machine-id
-	if [ -f "/etc/redhat-access-insights/machine-id" ]; then
-		cp /etc/redhat-access-insights/machine-id /etc/insights-client/machine-id
-	fi
-	#Migrate existing config
-	if [ -f "/etc/redhat-access-insights/redhat-access-insights.conf" ]; then
-		cp /etc/redhat-access-insights/redhat-access-insights.conf /etc/insights-client/insights-client.conf
-		sed -i 's/\[redhat-access-insights\]/\[insights-client\]/' /etc/insights-client/insights-client.conf
-	fi
-	#Migrate registration record
-	if [ -f "/etc/redhat-access-insights/.registered" ]; then
-		cp /etc/redhat-access-insights/.registered /etc/insights-client/.registered
-	fi
-	if [ -f "/etc/redhat-access-insights/.unregistered" ]; then
-		cp /etc/redhat-access-insights/.unregistered /etc/insights-client/.unregistered
-	fi
-	#Migrate last upload record
-	if [ -f "/etc/redhat-access-insights/.lastupload" ]; then
-		cp /etc/redhat-access-insights/.lastupload /etc/insights-client/.lastupload
-	fi
-	if ! [ -d "/etc/redhat-access-insights" ]; then
-		mkdir /etc/redhat-access-insights
-	fi
-	# Symlink new cron job if the old one exists. Remove the old one
-	if [ -f "/etc/cron.daily/redhat-access-insights" ]; then
-		rm -f /etc/cron.daily/redhat-access-insights
-		ln -sf /etc/insights-client/insights-client.cron /etc/cron.daily/insights-client                               
-	fi 
+    #Migrate existing machine-id
+    if  [ -f "/etc/redhat_access_proactive/machine-id" ]; then
+        cp /etc/redhat_access_proactive/machine-id /etc/insights-client/machine-id
+    fi
+    #Migrate OTHER existing machine-id
+    if [ -f "/etc/redhat-access-insights/machine-id" ]; then
+        cp /etc/redhat-access-insights/machine-id /etc/insights-client/machine-id
+    fi
+    #Migrate existing config
+    if [ -f "/etc/redhat-access-insights/redhat-access-insights.conf" ]; then
+        cp /etc/redhat-access-insights/redhat-access-insights.conf /etc/insights-client/insights-client.conf
+        sed -i 's/\[redhat-access-insights\]/\[insights-client\]/' /etc/insights-client/insights-client.conf
+    fi
+    #Migrate registration record
+    if [ -f "/etc/redhat-access-insights/.registered" ]; then
+        cp /etc/redhat-access-insights/.registered /etc/insights-client/.registered
+    fi
+    if [ -f "/etc/redhat-access-insights/.unregistered" ]; then
+        cp /etc/redhat-access-insights/.unregistered /etc/insights-client/.unregistered
+    fi
+    #Migrate last upload record
+    if [ -f "/etc/redhat-access-insights/.lastupload" ]; then
+        cp /etc/redhat-access-insights/.lastupload /etc/insights-client/.lastupload
+    fi
+    if ! [ -d "/etc/redhat-access-insights" ]; then
+        mkdir /etc/redhat-access-insights
+    fi
+    # Symlink new cron job if the old one exists. Remove the old one
+    if [ -f "/etc/cron.daily/redhat-access-insights" ]; then
+        rm -f /etc/cron.daily/redhat-access-insights
+        ln -sf /etc/insights-client/insights-client.cron /etc/cron.daily/insights-client                               
+    fi 
 fi
 
 # if the logging directory isnt created then make it
@@ -147,13 +147,13 @@ ln -sf /etc/insights-client/.unregistered /etc/redhat-access-insights/.unregiste
 ln -sf /etc/insights-client/.lastupload /etc/redhat-access-insights/.lastupload
 ln -sf /etc/insights-client/machine-id /etc/redhat-access-insights/machine-id
 if [ -f "/etc/insights-client/.lastupload" ]; then
-	setfacl -m g:insights:rwx /etc/insights-client/.lastupload
+    setfacl -m g:insights:rwx /etc/insights-client/.lastupload
 fi
 if [ -f "/etc/insights-client/.registered" ]; then
-	setfacl -m g:insights:rwx /etc/insights-client/.registered
+    setfacl -m g:insights:rwx /etc/insights-client/.registered
 fi
 if [ -f "/etc/insights-client/.unregistered" ]; then
-	setfacl -m g:insights:rwx /etc/insights-client/.unregistered
+    setfacl -m g:insights:rwx /etc/insights-client/.unregistered
 fi
 
 %postun

--- a/etc/insights-client.timer
+++ b/etc/insights-client.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Insights Client Timer Task
+Documentation=man:insights-client(8)
+After=network.target
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=14400
+
+[Install]
+WantedBy=multi-user.target

--- a/insights_client/__init__.py
+++ b/insights_client/__init__.py
@@ -27,7 +27,7 @@ try:
     insights_grpid = grp.getgrnam("insights").gr_gid
     curr_user_grps = os.getgroups()
 except:
-    sys.exit("User and group 'insights' not found. Exiting.")
+    insights_uid = insights_gid = insights_grpid = None
 
 
 def log(msg):
@@ -102,7 +102,12 @@ def _main():
     attempt to collect and upload with new, then current, then rpm
     if an egg fails a phase never try it again
     """
+
+    if not all(map(None, [insights_uid, insights_gid, insights_grpid])):
+        sys.exit("User and/or group 'insights' not found. Exiting.")
+
     sys.path = [STABLE_EGG, RPM_EGG] + sys.path
+
     try:
         # flake8 complains because these imports aren't at the top
         from insights.client import InsightsClient

--- a/insights_client/major_version.py
+++ b/insights_client/major_version.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+
+def major_version():
+    with open("/etc/redhat-release") as fp:
+        r = fp.read().strip()
+
+    release = r.split("release")[1].strip()
+    return release.split()[0].split(".")[0]
+
+
+if __name__ == "__main__":
+    print major_version()

--- a/major_version.py
+++ b/major_version.py
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-
-with open("/etc/redhat-release") as fp:
-    r = fp.read().strip()
-
-release = r.split("release")[1].strip()
-print release.split()[0].split(".")[0]

--- a/major_version.py
+++ b/major_version.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+with open("/etc/redhat-release") as fp:
+    r = fp.read().strip()
+
+release = r.split("release")[1].strip()
+print release.split()[0].split(".")[0]

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,13 @@
 from setuptools import setup, find_packages
 import subprocess
 
+with open("/etc/redhat-release") as fp:
+    r = fp.read().strip()
+
+release = r.split("release")[1].strip()
+rhel_version = int(release.split()[0].split(".")[0])
+print("RHEL VERSION: %d" % rhel_version)
+
 
 def get_version():
     f = open('insights_client/constants.py')
@@ -29,8 +36,36 @@ if __name__ == "__main__":
     # where stuff lands
     logpath = "/var/log/insights-client"
     confpath = "/etc/insights-client"
+    systemdpath = "/usr/lib/systemd/system"
     man5path = "/usr/share/man/man5/"
     man8path = "/usr/share/man/man8/"
+    conf_files = ['etc/insights-client.conf',
+                  'etc/.fallback.json',
+                  'etc/.fallback.json.asc',
+                  'etc/redhattools.pub.gpg',
+                  'etc/cert-api.access.redhat.com.pem',
+                  'etc/.exp.sed',
+                  'etc/rpm.egg',
+                  'etc/rpm.egg.asc']
+
+    if rhel_version == 6:
+        conf_files.append('etc/insights-client.cron')
+
+    data_files = [
+        # config files
+        (confpath, conf_files),
+
+        # man pages
+        (man5path, ['docs/insights-client.conf.5']),
+        (man8path, ['docs/insights-client.8']),
+
+        (logpath, []),
+    ]
+
+    if rhel_version >= 7:
+        data_files.append(
+            (systemdpath, ['etc/insights-client.service', 'etc/insights-client.timer'])
+        )
 
     setup(
         name="insights-client",
@@ -47,24 +82,7 @@ if __name__ == "__main__":
             'insights-client = insights_client:_main',
             'insights-client-run = insights_client.run:_main'
         ]},
-        data_files=[
-            # config files
-            (confpath, ['etc/insights-client.conf',
-                        'etc/.fallback.json',
-                        'etc/.fallback.json.asc',
-                        'etc/redhattools.pub.gpg',
-                        'etc/cert-api.access.redhat.com.pem',
-                        'etc/.exp.sed',
-                        'etc/insights-client.cron',
-                        'etc/rpm.egg',
-                        'etc/rpm.egg.asc']),
-
-            # man pages
-            (man5path, ['docs/insights-client.conf.5']),
-            (man8path, ['docs/insights-client.8']),
-
-            (logpath, [])
-        ],
+        data_files=data_files,
         description=SHORT_DESC,
         long_description=LONG_DESC
     )

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,9 @@
 
 from setuptools import setup, find_packages
 import subprocess
+from insights_client.major_version import major_version
 
-with open("/etc/redhat-release") as fp:
-    r = fp.read().strip()
-
-release = r.split("release")[1].strip()
-rhel_version = int(release.split()[0].split(".")[0])
-print("RHEL VERSION: %d" % rhel_version)
+rhel_version = int(major_version())
 
 
 def get_version():


### PR DESCRIPTION
One thing to note is that I'm doing a `sysemctl daemon-reload` when uninstalling on RHEL 7.  Not sure if this is okay to do, but otherwise I get `Access denied` errors when running `systemctl status insights-client` after uninstallation.