### PR TITLE
remove etag on uninstall (BZ1591371)

### DIFF
--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -191,6 +191,7 @@ rm -f /etc/insights-client/.unregistered
 rm -f /etc/insights-client/.lastupload
 rm -f /etc/insights-client/rpm.egg
 rm -f /etc/insights-client/rpm.egg.asc
+rm -f /etc/insights-client/.insights-core*.etag
 rm -rf /var/lib/insights
 rm -f /etc/ansible/facts.d/insights.fact
 rm -f /etc/ansible/facts.d/insights_machine_id.fact


### PR DESCRIPTION
Need to remove etag so that egg can be updated on reinstall

https://bugzilla.redhat.com/show_bug.cgi?id=1591371