### PR TITLE
Fix Python 3 incompatibility and remove unnecessary `map`

### DIFF
--- a/insights_client/__init__.py
+++ b/insights_client/__init__.py
@@ -119,7 +119,7 @@ def _main():
     if an egg fails a phase never try it again
     """
 
-    if not all(map(None, [insights_uid, insights_gid, insights_grpid])):
+    if not all([insights_uid, insights_gid, insights_grpid]):
         sys.exit("User and/or group 'insights' not found. Exiting.")
 
     validated_eggs = filter(gpg_validate, [STABLE_EGG, RPM_EGG])


### PR DESCRIPTION
Hello.

When trying to run insights-client on system with only Python 3, I found one incompatibility.

When the first argument to `map` function is `None` it
* is no-op in Python 2
* raises a `TypeError` in Python 3 because `None` is not callable

Original error:
```
Traceback (most recent call last):
  File "__init__.py", line 175, in <module>
    _main()
  File "__init__.py", line 122, in _main
    if not all(map(None, [insights_uid, insights_gid, insights_grpid])):
TypeError: 'NoneType' object is not callable
```

So I think that it's a good idea to remove `map`.