### PR TITLE
Spec/service/cron for insights-compliance

### DIFF
--- a/MANIFEST.rhel6
+++ b/MANIFEST.rhel6
@@ -1,6 +1,7 @@
 include etc/insights-client.spec
 include etc/insights-client.cron
 include etc/insights-client.conf
+include etc/insights-compliance.cron
 include etc/.exp.sed
 include etc/*.pem
 include etc/.fallback.json

--- a/MANIFEST.rhel7
+++ b/MANIFEST.rhel7
@@ -2,6 +2,8 @@ include etc/insights-client.service
 include etc/insights-client.timer
 include etc/insights-client.spec
 include etc/insights-client.conf
+include etc/insights-compliance.service
+include etc/insights-compliance.timer
 include etc/.exp.sed
 include etc/*.pem
 include etc/.fallback.json

--- a/etc/insights-client.conf
+++ b/etc/insights-client.conf
@@ -37,3 +37,10 @@
 
 # Display name for registration
 #display_name=
+
+#[compliance]
+# If empty, fetch it from Insights
+#policy_uuid =
+#profile = standard
+#content_path = /usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml
+#tailoring_path =

--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -66,6 +66,7 @@ getent passwd insights > /dev/null || \
 
 %if 0%{?rhel} != 6
 %systemd_post %{name}.timer
+%systemd_post insights-compliance.timer
 %endif
 
 # Only perform migration from redhat-access-insights to insights-client
@@ -101,11 +102,12 @@ if  [ $1 -eq 1  ]; then
     if [ -f "/etc/cron.daily/redhat-access-insights" ]; then
         rm -f /etc/cron.daily/redhat-access-insights
         %if 0%{?rhel} && 0%{?rhel} == 6
-            ln -sf /etc/insights-client/insights-client.cron /etc/cron.daily/insights-client                               
+            ln -sf /etc/insights-client/insights-client.cron /etc/cron.daily/insights-client
+            ln -sf /etc/insights-client/insights-compliance.cron /etc/cron.daily/insights-compliance
         %else
             %_bindir/systemctl start insights-client.timer
         %endif
-    fi 
+    fi
 fi
 
 # if the logging directory isnt created then make it
@@ -147,6 +149,8 @@ ln -sf /etc/insights-client/machine-id /etc/redhat-access-insights/machine-id
 %if 0%{?rhel} != 6
 %systemd_preun %{name}.timer
 %systemd_preun %{name}.service
+%systemd_preun insights-compliance.timer
+%systemd_preun insights-compliance.service
 %endif
 
 %postun
@@ -157,6 +161,8 @@ if [ "$1" -eq 0 ]; then
 %endif
 rm -f /etc/cron.daily/insights-client
 rm -f /etc/cron.weekly/insights-client
+rm -f /etc/cron.daily/insights-compliance
+rm -f /etc/cron.weekly/insights-compliance
 rm -f /etc/insights-client/.cache*
 rm -f /etc/insights-client/.registered
 rm -f /etc/insights-client/.unregistered
@@ -188,6 +194,8 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 %if 0%{?rhel} != 6
 %attr(644,root,root) %{_unitdir}/insights-client.service
 %attr(644,root,root) %{_unitdir}/insights-client.timer
+%attr(644,root,root) %{_unitdir}/insights-compliance.service
+%attr(644,root,root) %{_unitdir}/insights-compliance.timer
 %endif
 
 %attr(440,root,root) /etc/insights-client/*.pem
@@ -199,6 +207,7 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 
 %if 0%{?rhel} && 0%{?rhel} == 6
 %attr(755,root,root) /etc/insights-client/insights-client.cron
+%attr(755,root,root) /etc/insights-client/insights-compliance.cron
 %endif
 
 %attr(644,root,root) /etc/insights-client/rpm.egg

--- a/etc/insights-compliance.cron
+++ b/etc/insights-compliance.cron
@@ -1,0 +1,18 @@
+#!/bin/sh
+name=insights-client
+path=/usr/bin/${name}
+
+/sbin/service cgconfig status > /dev/null 2>&1
+if [ $? == 0 ];
+then
+    /bin/cgcreate -g memory,cpu,blkio:insights
+    /bin/cgset -r memory.limit_in_bytes=2147483648 insights
+    /bin/cgset -r memory.soft_limit_in_bytes=1073741824 insights
+    /bin/cgset -r memory.memsw.limit_in_bytes=2147483648 insights
+    /bin/cgset -r cpu.cfs_quota_us=30000 -r cpu.cfs_period_us=100000 insights
+    /bin/cgset -r blkio.weight=100 insights
+    /bin/cgexec -g memory,cpu,blkio:insights /usr/bin/timeout 30m ${path} --compliance --quiet
+    /bin/cgdelete memory,cpu,blkio:insights
+else
+    /usr/bin/timeout 10m ${path} --quiet
+fi

--- a/etc/insights-compliance.service
+++ b/etc/insights-compliance.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Insights Compliance Client.
+Documentation=man:insights-client(8)
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/insights-client --compliance
+Restart=no
+WatchdogSec=600
+CPUQuota=30%
+MemoryLimit=2G
+TasksMax=20
+BlockIOWeight=100
+ExecStartPost=/bin/bash -c "echo 2G > /sys/fs/cgroup/memory/system.slice/insights-compliance.service/memory.memsw.limit_in_bytes"
+ExecStartPost=/bin/bash -c "echo 1G > /sys/fs/cgroup/memory/system.slice/insights-compliance.service/memory.soft_limit_in_bytes"

--- a/etc/insights-compliance.timer
+++ b/etc/insights-compliance.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Insights Compliance Timer Task
+Documentation=man:insights-client(8)
+After=network.target
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=14400
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
These are meant to be scheduled independently of regular insights-client
runs, as OpenSCAP runs have the potential to be slower than 10 minutes,
which is insights-client timeout

**DO NOT MERGE YET - `insights-client --compliance` will fail as it's not implemented** 