### PR TITLE
change Insights URL to cloud.redhat.com

### DIFF
--- a/docs/insights-client.8
+++ b/docs/insights-client.8
@@ -6,7 +6,7 @@ insights\-client \- Red Hat Insights Client tool
 .SH "SYNOPSIS"
 .B insights-client [options]
 .SH "DESCRIPTION"
-\fBinsights\-client\fP is designed to help customers proactively resolve issues affecting business operations in Red Hat Enterprise Linux and Red Hat Cloud Infrastructure environments. View alerts or learn more at https://access.redhat.com/insights/.  Due to the dynamic nature of this application, some options may become available that are not described in the manual.  Please refer to the output of --help for the most up-to-date options.
+\fBinsights\-client\fP is designed to help customers proactively resolve issues affecting business operations in Red Hat Enterprise Linux and Red Hat Cloud Infrastructure environments. View alerts or learn more at https://cloud.redhat.com/insights/.  Due to the dynamic nature of this application, some options may become available that are not described in the manual.  Please refer to the output of --help for the most up-to-date options.
 
 
 .SH "OPTIONS"

--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -8,7 +8,7 @@ Release:                2%{?dist}
 Source0:                https://github.com/redhatinsights/insights-client/archive/insights-client-%{version}.tar.gz
 Epoch:                  0
 License:                GPLv2+
-URL:                    http://access.redhat.com/insights
+URL:                    https://cloud.redhat.com/insights
 Group:                  Applications/System
 Vendor:                 Red Hat, Inc.
 


### PR DESCRIPTION
In "insights-client" man page there is still old URL (which redirects to the right one though).