### PR TITLE
Display a message in motd Insights has not yet been used

### DIFF
--- a/docs/insights-client.8
+++ b/docs/insights-client.8
@@ -63,6 +63,9 @@ Check this host's registration status with Red Hat Insights.
 .IP "--net-debug"
 Log network activity.
 
+.SH "MOTD"
+A message will be displayed on login about \fBinsights\-client\fP if installed but has not yet been used at least once. To change or remove this message, edit the \f8/etc/insights-client/insights-client.motd\fP file.
+
 .SH "SEE ALSO"
 .BR insights-client.conf (5)
 

--- a/etc/insights-client.motd
+++ b/etc/insights-client.motd
@@ -1,0 +1,3 @@
+This system is not registered to Red Hat Insights. See https://cloud.redhat.com/
+To register this system, run: insights-client --register
+

--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -74,6 +74,9 @@ pathfix.py -pni "%{__python3}" %{buildroot}%{_bindir}/redhat-access-insights
 %else
 %{__python} setup.py install --root=${RPM_BUILD_ROOT} $PREFIX
 %endif
+#Link motd into place. setup.py does not support symlinks
+mkdir -p ${RPM_BUILD_ROOT}/etc/motd.d
+ln -snf /etc/insights-client/insights-client.motd ${RPM_BUILD_ROOT}/etc/motd.d/insights-client
 
 %post
 
@@ -192,6 +195,8 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 /etc/insights-client/.fallback.json
 /etc/insights-client/.fallback.json.asc
 /etc/insights-client/.exp.sed
+%config(noreplace) %attr(644,root,root) /etc/motd.d/insights-client
+%config(noreplace) %attr(644,root,root) /etc/insights-client/insights-client.motd
 
 %if 0%{?rhel} != 6
 %attr(644,root,root) %{_unitdir}/insights-client.service

--- a/insights_client/__init__.py
+++ b/insights_client/__init__.py
@@ -111,6 +111,7 @@ def run_phase(phase, client, validated_eggs):
         stdout, stderr = process.communicate()
         if process.returncode == 0:
             # phase successful, don't try another egg
+            update_motd_message()
             return
         if process.returncode == 1:
             # egg hit an error, try the next
@@ -122,6 +123,20 @@ def run_phase(phase, client, validated_eggs):
             sys.exit(process.returncode % 100)
     # All attemps to run phase have failed
     sys.exit(1)
+
+
+def update_motd_message():
+    """
+    motd displays a message about system not being registered. Once we have retrieved
+    any new egg, that means we've been registered at least once. We make that message
+    go away by removing /etc/motd.d/insights-client
+    It is intentional that message does not reappear if a system is then unregistered.
+    """
+    try:
+        if os.path.isfile(NEW_EGG):
+            os.remove("/etc/motd.d/insights-client")
+    except OSError:
+        pass  # Remove only if exists
 
 
 def _main():

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ if __name__ == "__main__":
     man5path = "/usr/share/man/man5/"
     man8path = "/usr/share/man/man8/"
     conf_files = ['etc/insights-client.conf',
+                  'etc/insights-client.motd',
                   'etc/.fallback.json',
                   'etc/.fallback.json.asc',
                   'etc/redhattools.pub.gpg',


### PR DESCRIPTION
Insights represents key functionality of the RHEL operating system. Customers are missing out on Value of Subscription when not enabled. Thus we display a message in motd when Insights is installed but has never been used.

We use a ```/etc/motd.d/``` drop in file to do this. Once insights-client has been
used (and a new egg has been retrieved) we drop this message.

The message can be edited or removed in the configuration file:

    /etc/insights-client/insights-client.motd

This motd message seems to represent part of the insights-client command-line
RPM packaged wrapper of InsightsClient and is less suited to the core functionality.