### PR TITLE
Point the motd message at /dev/null instead of removing

### DIFF
--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -73,7 +73,6 @@ pathfix.py -pni "%{__python3}" %{buildroot}%{_bindir}/redhat-access-insights
 %else
 %{__python2} setup.py install --root=${RPM_BUILD_ROOT} $PREFIX
 %endif
-#Link motd into place. setup.py does not support symlinks
 
 %post
 
@@ -136,8 +135,11 @@ if ! [ -d "/var/lib/insights" ]; then
 mkdir -m 644 /var/lib/insights
 fi
 
-# symlink the motd file
-ln -snf /etc/insights-client/insights-client.motd /etc/motd.d/insights-client
+#Link motd into place. Only do so if motd file doesn't exist
+if ! [ -L /etc/motd.d/insights-client ]; then
+    mkdir -p /etc/motd.d
+    ln -snf /etc/insights-client/insights-client.motd /etc/motd.d/insights-client
+fi
 
 # always perform legacy symlinks
 %posttrans

--- a/insights_client/__init__.py
+++ b/insights_client/__init__.py
@@ -21,6 +21,7 @@ ENV_EGG = os.environ.get("EGG")
 NEW_EGG = "/var/lib/insights/newest.egg"
 STABLE_EGG = "/var/lib/insights/last_stable.egg"
 RPM_EGG = "/etc/insights-client/rpm.egg"
+MOTD_FILE = "/etc/motd.d/insights-client"
 
 logger = logging.getLogger(__name__)
 
@@ -131,15 +132,16 @@ def run_phase(phase, client, validated_eggs):
 def update_motd_message():
     """
     motd displays a message about system not being registered. Once we have retrieved
-    any new egg, that means we've been registered at least once. We make that message
-    go away by removing /etc/motd.d/insights-client
+    any new egg, that means we've been used at least once. We make that message
+    go away by pointing /etc/motd.d/insights-client at an empty file
     It is intentional that message does not reappear if a system is then unregistered.
     """
     try:
         if os.path.isfile(NEW_EGG):
-            os.remove("/etc/motd.d/insights-client")
+            os.symlink(os.devnull, MOTD_FILE + ".tmp")
+            os.rename(MOTD_FILE + ".tmp", MOTD_FILE)
     except OSError:
-        pass  # Remove only if exists
+        pass  # In the case of multiple processes
 
 
 def _main():


### PR DESCRIPTION
Once insights-client has been used, we remove the message in
motd recommending use of Insights. Instead of removing the symlink
we instead point it at /dev/null.

We also need to be careful for upgrades. Upgrading the
insights-client package on a system where Insights has already
been used should not result in a motd message.