### PR TITLE
Added error catch for running insights-client-run

### DIFF
--- a/insights_client/__init__.py
+++ b/insights_client/__init__.py
@@ -39,7 +39,7 @@ def egg_version(egg):
     try:
         proc = Popen([sys.executable, '-c', 'from insights.client import InsightsClient; print(InsightsClient(None, False).version())'],
                      env={'PYTHONPATH': egg, 'PATH': os.getenv('PATH')}, stdout=PIPE, stderr=PIPE)
-    except OSError as e:
+    except OSError:
         return None
     stdout, stderr = proc.communicate()
     if six.PY3:

--- a/insights_client/run.py
+++ b/insights_client/run.py
@@ -3,6 +3,8 @@ import os
 import sys
 
 try:
+    if sys.argv[0] == "insights-client-run":
+        sys.exit("Error insights-client-run cannot be run on its own")
     try:
         from insights.client.phase import v1 as client
     except ImportError:


### PR DESCRIPTION
Added a simple error catch for running insights-client-run on its own.  

See https://projects.engineering.redhat.com/browse/RHCLOUD-107 for more information.  

There is a unittest to go along with change in the insights-core repo.