### PR TITLE
Added error catch for running insights-client-run

### DIFF
--- a/insights_client/run.py
+++ b/insights_client/run.py
@@ -3,6 +3,8 @@ import os
 import sys
 
 try:
+    if sys.argv[0] == "insights-client-run":
+        sys.exit("Error insights-client-run cannot be run on its own")
     try:
         from insights.client.phase import v1 as client
     except ImportError:

--- a/insights_client/tests/test_insights_client_run.py
+++ b/insights_client/tests/test_insights_client_run.py
@@ -1,0 +1,25 @@
+import subprocess
+
+from subprocess import PIPE
+
+
+def run_insights_client_run():
+    '''
+    Run the run.py script and test that it errors out.
+    '''
+    output = subprocess.Popen(['python', '../run.py'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    (stdout, stderr) = output.communicate()
+
+    return (output, stderr)
+
+
+def test_script_exit_code():
+    (output, stderr) = run_insights_client_run()
+
+    assert output.returncode != 0
+
+
+def test_script_error_check():
+    (output, stderr) = run_insights_client_run()
+
+    assert stderr is not None


### PR DESCRIPTION
I created a few simple unit tests to go along with the changes to the insights-client-run command and the error message that occurs when you run it.  

See https://projects.engineering.redhat.com/browse/RHCLOUD-107 for more info on the problem.