### PR TITLE
Include caught `ImportError` exception in exit message

### DIFF
--- a/insights_client/run.py
+++ b/insights_client/run.py
@@ -5,8 +5,11 @@ import sys
 try:
     try:
         from insights.client.phase import v1 as client
-    except ImportError:
-        sys.exit("Error importing insights.client for %s as %s" % (os.environ["INSIGHTS_PHASE"], os.environ["PYTHONPATH"]))
+    except ImportError as e:
+        sys.exit(
+            "Error importing insights.client for %s as %s: %s"
+            % (os.environ["INSIGHTS_PHASE"], os.environ["PYTHONPATH"], e)
+        )
 
     phase = getattr(client, os.environ["INSIGHTS_PHASE"])
     sys.exit(phase())


### PR DESCRIPTION
This will result in slightly more useful exit messages:

`Error importing insights.client for collect_and_output as /home/cloud-user/Projects/RedHatInsights/insights-core: No module named 'distro'`