### PR TITLE
Add a RANDOM_DELAY_SEC option to cron

### DIFF
--- a/MANIFEST.rhel6
+++ b/MANIFEST.rhel6
@@ -1,6 +1,7 @@
 include etc/insights-client.spec
 include etc/insights-client.cron
 include etc/insights-client.conf
+include etc/sysconfig/insights-client
 include etc/.exp.sed
 include etc/*.pem
 include etc/.fallback.json

--- a/etc/insights-client.cron
+++ b/etc/insights-client.cron
@@ -2,6 +2,15 @@
 name=insights-client
 path=/usr/bin/${name}
 
+RANDOM_DELAY_SEC=14400
+
+if [ -f /etc/sysconfig/insights-client ]; then
+    . /etc/sysconfig/insights-client
+fi
+
+DELAY=$((1 + RANDOM % ${RANDOM_DELAY_SEC}))
+echo "Sleeping for ${DELAY} seconds"
+/bin/sleep ${DELAY}
 /sbin/service cgconfig status > /dev/null 2>&1
 if [ $? == 0 ];
 then

--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -228,6 +228,7 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 
 %if 0%{?rhel} == 6
 %attr(755,root,root) /etc/insights-client/insights-client.cron
+%attr(644,root,root) /etc/sysconfig/insights-client
 %endif
 
 %attr(644,root,root) /etc/insights-client/rpm.egg

--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -228,7 +228,7 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 
 %if 0%{?rhel} == 6
 %attr(755,root,root) /etc/insights-client/insights-client.cron
-%attr(644,root,root) /etc/sysconfig/insights-client
+%config(noreplace) %attr(644,root,root) /etc/sysconfig/insights-client
 %endif
 
 %attr(644,root,root) /etc/insights-client/rpm.egg

--- a/etc/sysconfig/insights-client
+++ b/etc/sysconfig/insights-client
@@ -1,0 +1,6 @@
+# Maximum number of seconds to delay before running the insights-client. This
+# value is used as a divisor in a modulo operation to generate a random number,
+# therefore it is an error to set this value to zero.
+# The cron job sleeps for N seconds before running, where N is the randomly
+# generated number.
+RANDOM_DELAY_SEC=14400

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ if __name__ == "__main__":
     systemdpath = "/usr/lib/systemd/system"
     man5path = "/usr/share/man/man5/"
     man8path = "/usr/share/man/man8/"
+    sysconfigpath = "/etc/sysconfig/"
     conf_files = ['etc/insights-client.conf',
                   # 'etc/insights-client.motd',
                   'etc/.fallback.json',
@@ -65,6 +66,10 @@ if __name__ == "__main__":
     if rhel_version >= 7:
         data_files.append(
             (systemdpath, ['etc/insights-client.service', 'etc/insights-client.timer'])
+        )
+    else:
+        data_files.append(
+            (sysconfigpath, ['etc/sysconfig/insights-client'])
         )
 
     setup(


### PR DESCRIPTION
Define a sysconfig file at /etc/sysconfig/insights-client. This file contains variables used by the cron script.