### PR TITLE
Silently attempt writing to cgroup memory limits

### DIFF
--- a/etc/insights-client.service
+++ b/etc/insights-client.service
@@ -12,5 +12,5 @@ CPUQuota=30%
 MemoryLimit=2G
 TasksMax=300
 BlockIOWeight=100
-ExecStartPost=/bin/bash -c "if [ -d /sys/fs/cgroup/memory ]; then echo 2G > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.memsw.limit_in_bytes; fi"
-ExecStartPost=/bin/bash -c "if [ -d /sys/fs/cgroup/memory ]; then echo 1G > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.soft_limit_in_bytes; fi"
+ExecStartPost=-/bin/bash -c "echo 2G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.memsw.limit_in_bytes"
+ExecStartPost=-/bin/bash -c "echo 1G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.soft_limit_in_bytes"


### PR DESCRIPTION
In the case of the system not having cgroups enabled, these
ExecStartPost commands will not cause the unit to fail (because they are
prefixed with "-"). If cgroups are enabled, they will set the limits
appropriately. Either way, no errors will be logged to the journal (such
as "No such file or directory" errors) due to the stderr redirection).