### PR TITLE
Enable timer persistence

### DIFF
--- a/etc/insights-client.timer
+++ b/etc/insights-client.timer
@@ -14,6 +14,7 @@ After=network.target
 
 [Timer]
 OnCalendar=daily
+Persistent=true
 RandomizedDelaySec=14400
 
 [Install]


### PR DESCRIPTION
When enabled, the time when the service was last triggered is stored on disk. Now the client with be triggered if the host has been powered off since the last time the timer would have triggered.

Signed-off-by: Link Dupont <link@sub-pop.net>