### PR TITLE
Remove run entrypoint

### DIFF
--- a/etc/insights-client.spec
+++ b/etc/insights-client.spec
@@ -71,7 +71,6 @@ rm -rf ${RPM_BUILD_ROOT}
 %if 0%{?rhel} == 8
 %{__python3} setup.py install --root=${RPM_BUILD_ROOT} $PREFIX
 pathfix.py -pni "%{__python3}" %{buildroot}%{python3_sitelib}/insights_client/{__init__.py,major_version.py,run.py}
-pathfix.py -pni "%{__python3}" %{buildroot}%{_bindir}/insights-client-run
 pathfix.py -pni "%{__python3}" %{buildroot}%{_bindir}/insights-client
 pathfix.py -pni "%{__python3}" %{buildroot}%{_bindir}/redhat-access-insights
 %else
@@ -224,7 +223,6 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 
 %attr(755,root,root) %{_bindir}/insights-client
 %attr(755,root,root) %{_bindir}/redhat-access-insights
-%attr(755,root,root) %{_bindir}/insights-client-run
 
 %if 0%{?rhel} == 6
 %attr(755,root,root) /etc/insights-client/insights-client.cron

--- a/insights_client/__init__.py
+++ b/insights_client/__init__.py
@@ -85,7 +85,7 @@ def run_phase(phase, client, validated_eggs):
     Call the run script for the given phase.  If the phase succeeds returns the
     index of the egg that succeeded to be used in the next phase.
     """
-    insights_command = ["insights-client-run"] + sys.argv[1:]
+    insights_command = [sys.executable, os.path.join(os.path.dirname(__file__), "run.py")] + sys.argv[1:]
     config = client.get_conf()
     debug = config["debug"]
 

--- a/insights_client/__init__.py
+++ b/insights_client/__init__.py
@@ -66,12 +66,12 @@ def sorted_eggs(eggs):
 
 
 def gpg_validate(path):
-    if BYPASS_GPG:
-        return True
-
     # ENV egg might be None, so check if path defined, then check if it exists
     if not (path and os.path.exists(path) and os.path.exists(path + '.asc')):
         return False
+
+    if BYPASS_GPG:
+        return True
 
     gpg_template = '/usr/bin/gpg --verify --keyring %s %s %s'
     cmd = gpg_template % (GPG_KEY, path + '.asc', path)

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ if __name__ == "__main__":
         entry_points={'console_scripts': [
             'redhat-access-insights = insights_client:_main',
             'insights-client = insights_client:_main',
-            'insights-client-run = insights_client.run:_main'
         ]},
         data_files=data_files,
         description=SHORT_DESC,


### PR DESCRIPTION
Remove `insights-client-run` as a distributed "entrypoint". Since we don't want users running `insights-client-run` directly, it is not necessary to export as an public interface to the client. Instead, the main `insights-client` locates `run.py` in a relative directory to its own `__file__` path.

#### Bonus Bug Fix! ####
The results of `gpg_validate` are used to filter down a list to one of only valid eggs. If an egg does not exist and `BYPASS_GPG` is `True,` then the list will erroneously contain paths to eggs that do not exist. This ends up causing a later call to `Popen.communicate` to hang indefinitely. Moving the `BYPASS_GPG` check to below the file exists path avoids this.

**Note**: This PR obsoletes #92.