### PR TITLE
Add "insights-client-results.service"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,6 +4,9 @@ AM_INIT_AUTOMAKE([1.11 foreign])
 AC_CONFIG_MACRO_DIR([m4])
 AM_SILENT_RULES([yes])
 
+pkgsysconfdir=${sysconfdir}/$PACKAGE
+AC_SUBST([pkgsysconfdir])
+
 AC_PROG_SED
 PKG_PROG_PKG_CONFIG
 if test -z "$PKG_CONFIG"; then

--- a/data/cron/Makefile.am
+++ b/data/cron/Makefile.am
@@ -1,7 +1,7 @@
 pkgsysconfdir = $(sysconfdir)/insights-client
 sysconfigdir  = $(sysconfdir)/sysconfig
 
-dist_pkgsysconf_DATA = insights-client.cron
+dist_pkgsysconf_SCRIPTS = insights-client.cron
 dist_sysconfig_DATA = insights-client
 
 -include $(top_srcdir)/git.mk

--- a/data/cron/insights-client
+++ b/data/cron/insights-client
@@ -4,3 +4,9 @@
 # The cron job sleeps for N seconds before running, where N is the randomly
 # generated number.
 RANDOM_DELAY_SEC=14400
+
+# Check for insights results after uploading an archive. Setting this variable
+# to any non-empty value will enable a call to insights-client, checking for
+# results from the uploaded archive. Results, if received, are stored in
+# /var/lib/insights/.
+ENABLE_CHECK_RESULTS=1

--- a/data/cron/insights-client
+++ b/data/cron/insights-client
@@ -9,4 +9,4 @@ RANDOM_DELAY_SEC=14400
 # to any non-empty value will enable a call to insights-client, checking for
 # results from the uploaded archive. Results, if received, are stored in
 # /var/lib/insights/.
-ENABLE_CHECK_RESULTS=1
+ENABLE_CHECK_RESULTS="yes"

--- a/data/cron/insights-client.cron
+++ b/data/cron/insights-client.cron
@@ -10,6 +10,7 @@ name=insights-client
 path=/usr/bin/${name}
 
 RANDOM_DELAY_SEC=14400
+ENABLE_CHECK_RESULTS=1
 
 if [ -f /etc/sysconfig/insights-client ]; then
     . /etc/sysconfig/insights-client
@@ -29,6 +30,14 @@ then
     /bin/cgset -r blkio.weight=100 insights
     /bin/cgexec -g memory,cpu,blkio:insights /usr/bin/timeout 10m ${path} --retry 3 --quiet
     /bin/cgdelete memory,cpu,blkio:insights
+    if [ -z ${ENABLE_CHECK_RESULTS} ]; then
+        /bin/sleep 120
+        ${path} --check-results
+    fi
 else
     /usr/bin/timeout 10m ${path} --quiet
+    if [ -z ${ENABLE_CHECK_RESULTS} ]; then
+        /bin/sleep 120
+        /usr/bin/timeout 10m ${path} --check-results
+    fi
 fi

--- a/data/cron/insights-client.cron
+++ b/data/cron/insights-client.cron
@@ -10,7 +10,7 @@ name=insights-client
 path=/usr/bin/${name}
 
 RANDOM_DELAY_SEC=14400
-ENABLE_CHECK_RESULTS=1
+ENABLE_CHECK_RESULTS="yes"
 
 if [ -f /etc/sysconfig/insights-client ]; then
     . /etc/sysconfig/insights-client
@@ -30,13 +30,13 @@ then
     /bin/cgset -r blkio.weight=100 insights
     /bin/cgexec -g memory,cpu,blkio:insights /usr/bin/timeout 10m ${path} --retry 3 --quiet
     /bin/cgdelete memory,cpu,blkio:insights
-    if [ -z ${ENABLE_CHECK_RESULTS} ]; then
+    if [ -n ${ENABLE_CHECK_RESULTS} ]; then
         /bin/sleep 120
         ${path} --check-results
     fi
 else
     /usr/bin/timeout 10m ${path} --quiet
-    if [ -z ${ENABLE_CHECK_RESULTS} ]; then
+    if [ -n ${ENABLE_CHECK_RESULTS} ]; then
         /bin/sleep 120
         /usr/bin/timeout 10m ${path} --check-results
     fi

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -3,4 +3,21 @@ dist_systemdsystemunit_DATA = \
 	insights-client.timer \
 	$(NULL)
 
+systemdsystemunit_DATA = \
+	insights-client-results.service \
+	insights-client-results.path \
+	$(NULL)
+
+CLEANFILES = $(systemdsystemunit_DATA)
+EXTRA_DIST = \
+	insights-client-results.service.in \
+	insights-client-results.path.in \
+	$(NULL)
+
+%: %.in Makefile
+	$(AM_V_GEN) $(SED) \
+		-e 's,[@]bindir[@],$(bindir),g' \
+		-e 's,[@]pkgsysconfdir[@],$(pkgsysconfdir),g' \
+		$< > $@.tmp && mv $@.tmp $@
+
 -include $(top_srcdir)/git.mk

--- a/data/systemd/insights-client-results.path.in
+++ b/data/systemd/insights-client-results.path.in
@@ -1,0 +1,20 @@
+# This file is part of insights-client.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/insights-client-results.path.d/override.conf. Put the
+# desired overrides in that file and reload systemd.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Monitor @pkgsysconfdir@/.lastupload for modifications
+Documentation=man:insights-client(8)
+PartOf=insights-client.timer
+
+[Path]
+PathExists=@pkgsysconfdir@/.lastupload
+PathModified=@pkgsysconfdir@/.lastupload
+
+[Install]
+WantedBy=insights-client.timer

--- a/data/systemd/insights-client-results.service.in
+++ b/data/systemd/insights-client-results.service.in
@@ -1,0 +1,22 @@
+# This file is part of insights-client.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/insights-client-results.service.d/override.conf. Put the
+# desired overrides in that file and reload systemd. The next time this service
+# is run (either manually or via another systemd unit), the overridden values
+# will be in effect.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Check for insights from Red Hat Cloud Services
+Documentation=man:insights-client(8)
+After=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=no
+ExecStart=@bindir@/sleep 120
+ExecStart=@bindir@/insights-client --check-results
+Restart=no

--- a/data/systemd/insights-client.timer
+++ b/data/systemd/insights-client.timer
@@ -19,3 +19,4 @@ RandomizedDelaySec=14400
 
 [Install]
 WantedBy=multi-user.target
+Also=insights-client-results.path


### PR DESCRIPTION
Adds a systemd "path" unit that watches /etc/insights-client/.lastupload for modification. The unit it triggers then sleeps for 120 seconds (:frowning:) before running --check-update.

The Also= clause in insights-client.timer causes insights-client-results.path to be enabled when insights-client.timer is. This keeps the user experience "the same". Enabling just insights-client.timer will also enable insights-client-results.path. insights-client-results.path adds a PartOf= dependency to insights-client.timer, so that it is started and stopped when insights-client.timer is started.

The new ENABLE_CHECK_RESULTS variable in sysconfig enables this same functionality for cron-based systems.