### PR TITLE
systemd: timer unit updates

### DIFF
--- a/data/systemd/insights-client.timer
+++ b/data/systemd/insights-client.timer
@@ -10,7 +10,8 @@
 [Unit]
 Description=Insights Client Timer Task
 Documentation=man:insights-client(8)
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Timer]
 OnCalendar=daily
@@ -18,5 +19,5 @@ Persistent=true
 RandomizedDelaySec=14400
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=timers.target
 Also=insights-client-results.path


### PR DESCRIPTION
- Make timer depend on network-online, ensuring that network is up before starting
- Make timers.target start insights-client.timer rather than multi-user

Fixes: RHCLOUD-4398, RHBZ#1798373