### PR TITLE
legacy: add redhat-access-insights

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,11 +1,18 @@
 SUBDIRS = insights_client
 
-bin_SCRIPTS = insights-client
+bin_SCRIPTS = \
+	insights-client \
+	redhat-access-insights \
+	$(NULL)
 CLEANFILES = $(bin_SCRIPTS)
-EXTRA_DIST = insights-client.in
+EXTRA_DIST = \
+	insights-client.in \
+	redhat-access-insights.in \
+	$(NULL)
 
 %: %.in Makefile
 	$(AM_V_GEN) $(SED) \
+		-e 's,[@]bindir[@],$(bindir),g' \
 		-e 's,[@]pythondir[@],$(pythondir),g' \
 		-e 's,[@]PYTHON[@],$(PYTHON),g' \
 		$< > $@.tmp && mv $@.tmp $@

--- a/src/redhat-access-insights.in
+++ b/src/redhat-access-insights.in
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "WARNING: $(basename $0) is deprecated and will be removed in a future release."
+exec @bindir@/insights-client $@

--- a/src/redhat-access-insights.in
+++ b/src/redhat-access-insights.in
@@ -1,4 +1,5 @@
 #!/bin/sh
 
 echo "WARNING: $(basename $0) is deprecated and will be removed in a future release."
+sleep 3
 exec @bindir@/insights-client $@


### PR DESCRIPTION
Install a legacy compatibility script to support the deprecated 'redhat-access-insights' executable.

Fixes: RHCLOUD-5409