### PR TITLE
Update deprecation message

### DIFF
--- a/src/redhat-access-insights.in
+++ b/src/redhat-access-insights.in
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-echo "WARNING: $(basename $0) is deprecated and will be removed in a future release."
+echo "WARNING: $(basename $0) is deprecated and will be removed in a future release; use 'insights-client' instead."
 sleep 3
 exec @bindir@/insights-client $@


### PR DESCRIPTION
Update the deprecation message when running redhat-access-insights to guide users to the new client name.