### PR TITLE
Remove echo from cron

### DIFF
--- a/data/cron/insights-client.cron
+++ b/data/cron/insights-client.cron
@@ -17,7 +17,6 @@ if [ -f /etc/sysconfig/insights-client ]; then
 fi
 
 DELAY=$((1 + RANDOM % ${RANDOM_DELAY_SEC}))
-echo "Sleeping for ${DELAY} seconds"
 /bin/sleep ${DELAY}
 /sbin/service cgconfig status > /dev/null 2>&1
 if [ $? == 0 ];


### PR DESCRIPTION
When a cron job generates output on stdout, it creates local mail messages in /var/spool/mail/root. This isn't necessary, especially for informational log messages like "Sleeping for N seconds". This PR removes the echo statement from the cron script.

Fixes: RHCLOUD-6140 RHBZ#1828778