### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,13 +1,13 @@
-#!/bin/sh
+#!/bin/bash
 # Run this to generate all the initial makefiles, etc.
 test -n "$srcdir" || srcdir=$(dirname "$0")
 test -n "$srcdir" || srcdir=.
 
 olddir=$(pwd)
 
-cd $srcdir
+cd $srcdir || exit
 
-(test -f configure.ac) || {
+test -f configure.ac || {
 	echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
 	exit 1
 }
@@ -15,7 +15,7 @@ cd $srcdir
 # shellcheck disable=SC2016
 PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
 
-if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
+if [ "$#" = 0 ] && [ "x$NOCONFIGURE" = "x" ]; then
 	echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
 	echo "*** If you wish to pass any to it, please specify them on the" >&2
 	echo "*** '$0' command line." >&2
@@ -26,11 +26,13 @@ aclocal --install -I m4 || exit 1
 autoconf --force || exit 1
 automake --add-missing --copy --force-missing || exit 1
 
-cd "$olddir"
+cd "$olddir" || exit
 if [ "$NOCONFIGURE" = "" ]; then
 	$srcdir/configure "$@" || exit 1
 
-	if [ "$1" = "--help" ]; then exit 0 else
+	if [ "$1" = "--help" ]; then
+		exit 0 
+	else
 		echo "Now type 'make' to compile $PKG_NAME" || exit 1
 	fi
 else

--- a/data/cron/insights-client.cron
+++ b/data/cron/insights-client.cron
@@ -20,7 +20,7 @@ fi
 DELAY=$((1 + RANDOM % ${RANDOM_DELAY_SEC}))
 /bin/sleep ${DELAY}
 /sbin/service cgconfig status > /dev/null 2>&1
-if [ $? == 0 ];
+if ! /sbin/service cgconfig status > /dev/null 2>&1;
 then
     /bin/cgcreate -g memory,cpu,blkio:insights
     /bin/cgset -r memory.limit_in_bytes=2147483648 insights

--- a/data/cron/insights-client.cron
+++ b/data/cron/insights-client.cron
@@ -30,13 +30,13 @@ then
     /bin/cgset -r blkio.weight=100 insights
     /bin/cgexec -g memory,cpu,blkio:insights /usr/bin/timeout 10m ${path} --retry 3 --quiet
     /bin/cgdelete memory,cpu,blkio:insights
-    if [ -n ${ENABLE_CHECK_RESULTS} ]; then
+    if [[ -n ${ENABLE_CHECK_RESULTS} ]]; then
         /bin/sleep 120
         ${path} --check-results
     fi
 else
     /usr/bin/timeout 10m ${path} --quiet
-    if [ -n ${ENABLE_CHECK_RESULTS} ]; then
+    if [[ -n ${ENABLE_CHECK_RESULTS} ]]; then
         /bin/sleep 120
         /usr/bin/timeout 10m ${path} --check-results
     fi

--- a/data/cron/insights-client.cron
+++ b/data/cron/insights-client.cron
@@ -13,6 +13,7 @@ RANDOM_DELAY_SEC=14400
 ENABLE_CHECK_RESULTS="yes"
 
 if [ -f /etc/sysconfig/insights-client ]; then
+    # shellcheck source=insights-client
     . /etc/sysconfig/insights-client
 fi
 

--- a/data/cron/insights-client.cron
+++ b/data/cron/insights-client.cron
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # This file is part of insights-client.
 #

--- a/data/cron/insights-client.cron
+++ b/data/cron/insights-client.cron
@@ -19,8 +19,7 @@ fi
 
 DELAY=$((1 + RANDOM % RANDOM_DELAY_SEC))
 /bin/sleep ${DELAY}
-/sbin/service cgconfig status > /dev/null 2>&1
-if ! /sbin/service cgconfig status > /dev/null 2>&1;
+if [ "$(/sbin/service cgconfig status)" == "Running" ];
 then
     /bin/cgcreate -g memory,cpu,blkio:insights
     /bin/cgset -r memory.limit_in_bytes=2147483648 insights

--- a/data/cron/insights-client.cron
+++ b/data/cron/insights-client.cron
@@ -17,7 +17,7 @@ if [ -f /etc/sysconfig/insights-client ]; then
     . /etc/sysconfig/insights-client
 fi
 
-DELAY=$((1 + RANDOM % ${RANDOM_DELAY_SEC}))
+DELAY=$((1 + RANDOM % RANDOM_DELAY_SEC))
 /bin/sleep ${DELAY}
 /sbin/service cgconfig status > /dev/null 2>&1
 if ! /sbin/service cgconfig status > /dev/null 2>&1;

--- a/src/redhat-access-insights.in
+++ b/src/redhat-access-insights.in
@@ -2,4 +2,4 @@
 
 echo "WARNING: $(basename "$0") is deprecated and will be removed in a future release; use 'insights-client' instead."
 sleep 3
-exec @bindir@/insights-client $@
+exec @bindir@/insights-client "$@"

--- a/src/redhat-access-insights.in
+++ b/src/redhat-access-insights.in
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-echo "WARNING: $(basename $0) is deprecated and will be removed in a future release; use 'insights-client' instead."
+echo "WARNING: $(basename "$0") is deprecated and will be removed in a future release; use 'insights-client' instead."
 sleep 3
 exec @bindir@/insights-client $@


### PR DESCRIPTION
Run cron script and redhat-access-insights script through shellcheck.

Fixes: RHCLOUD-6204