### PR TITLE
Insights register

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,14 @@ fi
 AC_MSG_RESULT([$have_motdd])
 AM_CONDITIONAL([HAVE_MOTDD], [test x"$have_motdd" = x"yes"])
 
+dnl Optionally install a systemd unit to automatically register insights-client
+dnl when it detects an RHSM subscription.
+AC_ARG_ENABLE([auto-registration],
+    [AS_HELP_STRING([--enable-auto-registration],
+        [enable automatic registration @<:@default: no@:>@])],
+    [auto_registration=${enableval}], [auto_registration=no])
+AM_CONDITIONAL([ENABLE_AUTO_REGISTRATION], [test "x${auto_registration}" = xyes])
+
 AC_CONFIG_FILES([
     Makefile
     data/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,9 @@ AS_IF([test x"$HAVE_PYMOD_RHSM" = x"no"],[
     AC_MSG_WARN([missing python module: rhsm])
 ])
 
+dnl Set up required systemd directories and automake variables
 SYSTEMD_SYSTEMUNITDIR
+SYSTEMD_SYSTEMPRESETDIR
 
 dnl Check for version of pam_motd.so that supports motd.d.
 dnl This is ugly but seems to be the most reliable way to detect which version

--- a/data/systemd/80-insights.preset
+++ b/data/systemd/80-insights.preset
@@ -1,0 +1,2 @@
+enable insights-register.path
+enable insights-unregister.path

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -6,12 +6,14 @@ dist_systemdsystemunit_DATA = \
 systemdsystemunit_DATA = \
 	insights-client-results.service \
 	insights-client-results.path \
+	insights-register.service \
 	$(NULL)
 
 CLEANFILES = $(systemdsystemunit_DATA)
 EXTRA_DIST = \
 	insights-client-results.service.in \
 	insights-client-results.path.in \
+	insights-register.service.in \
 	$(NULL)
 
 %: %.in Makefile

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -12,6 +12,8 @@ if ENABLE_AUTO_REGISTRATION
 systemdsystemunit_DATA += \
 	insights-register.service \
 	insights-register.path \
+	insights-unregister.service \
+	insights-unregister.path \
 	$(NULL)
 endif
 
@@ -21,6 +23,8 @@ EXTRA_DIST = \
 	insights-client-results.path.in \
 	insights-register.service.in \
 	insights-register.path.in \
+	insights-unregister.service.in \
+	insights-unregister.path.in \
 	$(NULL)
 
 %: %.in Makefile

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -7,6 +7,7 @@ systemdsystemunit_DATA = \
 	insights-client-results.service \
 	insights-client-results.path \
 	insights-register.service \
+	insights-register.path \
 	$(NULL)
 
 CLEANFILES = $(systemdsystemunit_DATA)
@@ -14,12 +15,14 @@ EXTRA_DIST = \
 	insights-client-results.service.in \
 	insights-client-results.path.in \
 	insights-register.service.in \
+	insights-register.path.in \
 	$(NULL)
 
 %: %.in Makefile
 	$(AM_V_GEN) $(SED) \
 		-e 's,[@]bindir[@],$(bindir),g' \
 		-e 's,[@]pkgsysconfdir[@],$(pkgsysconfdir),g' \
+		-e 's,[@]sysconfdir[@],$(sysconfdir),g' \
 		$< > $@.tmp && mv $@.tmp $@
 
 -include $(top_srcdir)/git.mk

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -6,9 +6,14 @@ dist_systemdsystemunit_DATA = \
 systemdsystemunit_DATA = \
 	insights-client-results.service \
 	insights-client-results.path \
+	$(NULL)
+
+if ENABLE_AUTO_REGISTRATION
+systemdsystemunit_DATA += \
 	insights-register.service \
 	insights-register.path \
 	$(NULL)
+endif
 
 CLEANFILES = $(systemdsystemunit_DATA)
 EXTRA_DIST = \

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -8,12 +8,18 @@ systemdsystemunit_DATA = \
 	insights-client-results.path \
 	$(NULL)
 
+systemdsystempreset_DATA = \
+	$(NULL)
+
 if ENABLE_AUTO_REGISTRATION
 systemdsystemunit_DATA += \
 	insights-register.service \
 	insights-register.path \
 	insights-unregister.service \
 	insights-unregister.path \
+	$(NULL)
+systemdsystempreset_DATA += \
+	80-insights.preset \
 	$(NULL)
 endif
 
@@ -25,6 +31,7 @@ EXTRA_DIST = \
 	insights-register.path.in \
 	insights-unregister.service.in \
 	insights-unregister.path.in \
+	80-insights.preset \
 	$(NULL)
 
 %: %.in Makefile

--- a/data/systemd/insights-register.path.in
+++ b/data/systemd/insights-register.path.in
@@ -1,0 +1,18 @@
+# This file is part of insights-client.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/insights-register.path.d/override.conf. Put the desired
+# overrides in that file and reload systemd.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Automatically Register with Red Hat Insights Path Watch
+Documentation=man:insights-client(8)
+
+[Path]
+PathExists=@sysconfdir@/pki/consumer/cert.pem
+
+[Install]
+WantedBy=multi-user.target

--- a/data/systemd/insights-register.service.in
+++ b/data/systemd/insights-register.service.in
@@ -1,0 +1,27 @@
+# This file is part of insights-client.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/insights-register.service.d/override.conf. Put the desired
+# overrides in that file and reload systemd. The next time this service is run
+# (either manually or via a systemd timer), the overridden values will be in
+# effect.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Insights Registration
+Documentation=man:insights-client(8)
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart=@bindir@/insights-client --register
+Restart=no
+WatchdogSec=900
+CPUQuota=30%
+MemoryLimit=2G
+TasksMax=300
+BlockIOWeight=100
+ExecStartPost=-/bin/bash -c "echo 2G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-register.service/memory.memsw.limit_in_bytes"
+ExecStartPost=-/bin/bash -c "echo 1G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-register.service/memory.soft_limit_in_bytes"

--- a/data/systemd/insights-register.service.in
+++ b/data/systemd/insights-register.service.in
@@ -10,7 +10,7 @@
 # For more information about systemd drop-in files, see systemd.unit(5).
 
 [Unit]
-Description=Insights Registration
+Description=Automatically Register with Red Hat Insights
 Documentation=man:insights-client(8)
 After=network-online.target
 
@@ -25,3 +25,4 @@ TasksMax=300
 BlockIOWeight=100
 ExecStartPost=-/bin/bash -c "echo 2G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-register.service/memory.memsw.limit_in_bytes"
 ExecStartPost=-/bin/bash -c "echo 1G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-register.service/memory.soft_limit_in_bytes"
+ExecStopPost=systemctl mask --now insights-register.path

--- a/data/systemd/insights-unregister.path.in
+++ b/data/systemd/insights-unregister.path.in
@@ -1,0 +1,18 @@
+# This file is part of insights-client.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/insights-unregister.path.d/override.conf. Put the desired
+# overrides in that file and reload systemd.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Automatically Unregister from Red Hat Insights Path Watch
+Documentation=man:insights-client(8)
+
+[Path]
+PathChanged=@sysconfdir@/pki/consumer/cert.pem
+
+[Install]
+WantedBy=multi-user.target

--- a/data/systemd/insights-unregister.service.in
+++ b/data/systemd/insights-unregister.service.in
@@ -19,4 +19,5 @@ ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
 Type=simple
 ExecStart=@bindir@/insights-client --unregister --force
 ExecStopPost=systemctl unmask --now insights-register.path
+ExecStopPost=systemctl start insights-register.path
 Restart=no

--- a/data/systemd/insights-unregister.service.in
+++ b/data/systemd/insights-unregister.service.in
@@ -17,5 +17,5 @@ ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
 
 [Service]
 Type=simple
-ExecStart=@bindir@/insights-client --unregister
+ExecStart=@bindir@/insights-client --unregister --force
 Restart=no

--- a/data/systemd/insights-unregister.service.in
+++ b/data/systemd/insights-unregister.service.in
@@ -18,4 +18,5 @@ ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
 [Service]
 Type=simple
 ExecStart=@bindir@/insights-client --unregister --force
+ExecStopPost=systemctl unmask --now insights-register.path
 Restart=no

--- a/data/systemd/insights-unregister.service.in
+++ b/data/systemd/insights-unregister.service.in
@@ -1,0 +1,21 @@
+# This file is part of insights-client.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/insights-unregister.service.d/override.conf. Put the
+# desired overrides in that file and reload systemd. The next time this service
+# is run (either manually or via a systemd timer), the overridden values will be
+# in effect.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Automatically Unregister from Red Hat Insights
+Documentation=man:insights-client(8)
+After=network-online.target
+ConditionPathExists=!@sysconfdir@/pki/consumer/cert.pem
+
+[Service]
+Type=simple
+ExecStart=@bindir@/insights-client --unregister
+Restart=no


### PR DESCRIPTION
Add a systemd path unit that watches for the existence of `/etc/pki/consumer/cert.pem` and `/etc/pki/consumer/key.pem`. If those files exist, the unit triggers a service that invokes `insights-client --register`. Upon successful execution of `insights-client --register`, the service unit masks the path unit, disabling it from further execution.

This unit is installed only if `insights-client` is built with the `--enable-auto-registration` flag. This flag defaults to 'no'. This installs two additional systemd unit files: `insights-register.path` and `insights-register.service`. Finally, `insights-register.path` must be enabled post installation. On systems that have been configured to use this auto-registration mechanism, in order to opt out of automatic registration, mask the path unit prior to registration with RHSM.