### PR TITLE
Collect runtime statistics about phase execution

### DIFF
--- a/src/insights_client/Makefile.am
+++ b/src/insights_client/Makefile.am
@@ -3,6 +3,7 @@ insights_clientdir = $(pythondir)/insights_client
 insights_client_PYTHON = \
 	__init__.py \
 	run.py \
+	metrics.py \
 	$(NULL)
 
 nodist_insights_client_PYTHON = \

--- a/src/insights_client/Makefile.am
+++ b/src/insights_client/Makefile.am
@@ -2,8 +2,9 @@ insights_clientdir = $(pythondir)/insights_client
 
 insights_client_PYTHON = \
 	__init__.py \
-	run.py \
 	metrics.py \
+	run.py \
+	utc.py \
 	$(NULL)
 
 nodist_insights_client_PYTHON = \

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -45,6 +45,7 @@ class MetricsHTTPClient(requests.Session):
         """
         if self.base_url == "cert-api.access.redhat.com":
             api_prefix = "/r/insights/platform"
+            self.verify = "/etc/insights-client/cert-api.access.redhat.com.pem"
         else:
             api_prefix = "/api"
         url = "https://{}{}/module-update-router/v1/event".format(

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -1,6 +1,11 @@
-import socket
+import re
 
 import requests
+import rhsm
+from six.moves import configparser
+
+AUTH_METHOD_BASIC = "BASIC"
+AUTH_METHOD_CERT = "CERT"
 
 
 class MetricsHTTPClient(requests.Session):
@@ -9,7 +14,9 @@ class MetricsHTTPClient(requests.Session):
     runtime metrics about insights-client back to the Insights Platform.
     """
 
-    def __init__(self, cert_file, key_file, base_url=None):
+    def __init__(
+        self, cert_file=None, key_file=None, base_url=None, config_file=None,
+    ):
         """
         __init__ creates and configures a new MetricsHTTPClient
 
@@ -17,25 +24,40 @@ class MetricsHTTPClient(requests.Session):
         :param key: path to private key
         """
         super(MetricsHTTPClient, self).__init__()
-        self.cert = (cert_file, key_file)
-        if base_url is None:
-            for base_url in [
-                "cert.cloud.redhat.com",
-                "cert-api.access.redhat.com",
-            ]:
-                try:
-                    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                    s.connect((base_url, 443))
-                    self.base_url = base_url
-                    break
-                except Exception as e:
-                    print(e)
-                finally:
-                    s.close()
+
+        cfg = configparser.RawConfigParser()
+        cfg.read(config_file)
+
+        rhsm_cfg = rhsm.config.initConfig()
+        rhsm_server_hostname = rhsm_cfg.get("server", "hostname")
+        rhsm_server_port = rhsm_cfg.get("server", "port")
+
+        match = re.match("subscription.rhsm(.stage)?.redhat.com", rhsm_server_hostname)
+        if match is None:
+            # Assume Satellite-managed and configure for Satellite-proxied access
+            self.base_url = rhsm_server_hostname
+            self.port = rhsm_server_port
+            self.cert = (cert_file, key_file)
+            self.api_prefix = "/redhat_access/r/insights/platform"
         else:
-            self.base_url = base_url
-        if self.base_url is None:
-            raise Exception("Unable to connect to Red Hat Insights Platform")
+            try:
+                auth_method = cfg.get("insights-client", "authmethod")
+            except configparser.NoOptionError:
+                auth_method = AUTH_METHOD_CERT
+
+            if auth_method == AUTH_METHOD_BASIC:
+                self.base_url = "cloud.redhat.com"
+                self.port = 443
+                u = cfg.get("insights-client", "username")
+                p = cfg.get("insights-client", "password")
+                self.auth = (u, p)
+                self.api_prefix = "/api"
+
+            if auth_method == AUTH_METHOD_CERT:
+                self.base_url = "cert.cloud.redhat.com"
+                self.port = 443
+                self.cert = (cert_file, key_file)
+                self.api_prefix = "/api"
 
     def post(self, event):
         """
@@ -43,12 +65,7 @@ class MetricsHTTPClient(requests.Session):
 
         :param event: a dictionary describing an event object
         """
-        if self.base_url == "cert-api.access.redhat.com":
-            api_prefix = "/r/insights/platform"
-            self.verify = "/etc/insights-client/cert-api.access.redhat.com.pem"
-        else:
-            api_prefix = "/api"
-        url = "https://{}{}/module-update-router/v1/event".format(
-            self.base_url, api_prefix
+        url = "https://{}:{}{}/module-update-router/v1/event".format(
+            self.base_url, self.port, self.api_prefix
         )
         return super(MetricsHTTPClient, self).post(url, json=event)

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -15,7 +15,12 @@ class MetricsHTTPClient(requests.Session):
     """
 
     def __init__(
-        self, cert_file=None, key_file=None, base_url=None, config_file=None,
+        self,
+        cert_file=None,
+        key_file=None,
+        base_url=None,
+        config_file=None,
+        rhsm_config_file="/etc/rhsm/rhsm.conf",
     ):
         """
         __init__ creates and configures a new MetricsHTTPClient
@@ -28,10 +33,13 @@ class MetricsHTTPClient(requests.Session):
         cfg = configparser.RawConfigParser()
         cfg.read(config_file)
 
-        rhsm_cfg = rhsm.config.initConfig()
+        rhsm_cfg = configparser.RawConfigParser()
+        rhsm_cfg.read(rhsm_config_file)
+
         rhsm_server_hostname = rhsm_cfg.get("server", "hostname")
         rhsm_server_port = rhsm_cfg.get("server", "port")
         rhsm_rhsm_repo_ca_cert = rhsm_cfg.get("rhsm", "repo_ca_cert")
+        rhsm_rhsm_consumerCertDir = rhsm_cfg.get("rhsm", "consumerCertDir")
 
         match = re.match("subscription.rhsm(.stage)?.redhat.com", rhsm_server_hostname)
         if match is None:

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -1,0 +1,53 @@
+import socket
+
+import requests
+
+
+class MetricsHTTPClient(requests.Session):
+    """
+    MetricsHTTPClient is a `requests.Session` subclass, configured to transmit
+    runtime metrics about insights-client back to the Insights Platform.
+    """
+
+    def __init__(self, cert_file, key_file, base_url=None):
+        """
+        __init__ creates and configures a new MetricsHTTPClient
+
+        :param cert: path to certificate
+        :param key: path to private key
+        """
+        super(MetricsHTTPClient, self).__init__()
+        self.cert = (cert_file, key_file)
+        if base_url is None:
+            for base_url in [
+                "cert.cloud.redhat.com",
+                "cert-api.access.redhat.com",
+            ]:
+                try:
+                    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    s.connect((base_url, 443))
+                    self.base_url = base_url
+                    break
+                except Exception as e:
+                    print(e)
+                finally:
+                    s.close()
+        else:
+            self.base_url = base_url
+        if self.base_url is None:
+            raise Exception("Unable to connect to Red Hat Insights Platform")
+
+    def post(self, event):
+        """
+        post sends `event` to the Insights Platform.
+
+        :param event: a dictionary describing an event object
+        """
+        if self.base_url == "cert-api.access.redhat.com":
+            api_prefix = "/r/insights/platform"
+        else:
+            api_prefix = "/api"
+        url = "https://{}{}/module-update-router/v1/event".format(
+            self.base_url, api_prefix
+        )
+        return super(MetricsHTTPClient, self).post(url, json=event)

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -33,7 +33,7 @@ class MetricsHTTPClient(requests.Session):
         cfg = configparser.RawConfigParser()
         cfg.read(config_file)
 
-        rhsm_cfg = configparser.RawConfigParser()
+        rhsm_cfg = configparser.ConfigParser()
         rhsm_cfg.read(rhsm_config_file)
 
         rhsm_server_hostname = rhsm_cfg.get("server", "hostname")

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -31,6 +31,7 @@ class MetricsHTTPClient(requests.Session):
         rhsm_cfg = rhsm.config.initConfig()
         rhsm_server_hostname = rhsm_cfg.get("server", "hostname")
         rhsm_server_port = rhsm_cfg.get("server", "port")
+        rhsm_rhsm_repo_ca_cert = rhsm_cfg.get("rhsm", "repo_ca_cert")
 
         match = re.match("subscription.rhsm(.stage)?.redhat.com", rhsm_server_hostname)
         if match is None:
@@ -38,6 +39,7 @@ class MetricsHTTPClient(requests.Session):
             self.base_url = rhsm_server_hostname
             self.port = rhsm_server_port
             self.cert = (cert_file, key_file)
+            self.verify = rhsm_rhsm_repo_ca_cert
             self.api_prefix = "/redhat_access/r/insights/platform"
         else:
             try:

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -1,7 +1,7 @@
+import os.path
 import re
 
 import requests
-import rhsm
 from six.moves import configparser
 
 AUTH_METHOD_BASIC = "BASIC"
@@ -40,6 +40,11 @@ class MetricsHTTPClient(requests.Session):
         rhsm_server_port = rhsm_cfg.get("server", "port")
         rhsm_rhsm_repo_ca_cert = rhsm_cfg.get("rhsm", "repo_ca_cert")
         rhsm_rhsm_consumerCertDir = rhsm_cfg.get("rhsm", "consumerCertDir")
+
+        if cert_file is None:
+            cert_file = os.path.join(rhsm_rhsm_consumerCertDir, "cert.pem")
+        if key_file is None:
+            key_file = os.path.join(rhsm_rhsm_consumerCertDir, "key.pem")
 
         match = re.match("subscription.rhsm(.stage)?.redhat.com", rhsm_server_hostname)
         if match is None:

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -80,7 +80,7 @@ class MetricsHTTPClient(requests.Session):
 
         :param event: a dictionary describing an event object
         """
-        url = "https://{}:{}{}/module-update-router/v1/event".format(
+        url = "https://{0}:{1}{2}/module-update-router/v1/event".format(
             self.base_url, self.port, self.api_prefix
         )
         return super(MetricsHTTPClient, self).post(url, json=event)

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -16,7 +16,9 @@ try:
 
     phase = getattr(client, os.environ["INSIGHTS_PHASE"])
     metrics_client = metrics.MetricsHTTPClient(
-        "/etc/pki/consumer/cert.pem", "/etc/pki/consumer/key.pem"
+        cert_file="/etc/pki/consumer/cert.pem",
+        key_file="/etc/pki/consumer/key.pem",
+        config_file="/etc/insights-client/insights-client.conf",
     )
     code = 0
     with open("/etc/insights-client/machine-id") as f:
@@ -64,4 +66,7 @@ try:
         metrics_client.post(event)
         sys.exit(code)
 except KeyboardInterrupt:
+    sys.exit(1)
+except Exception as e:
+    print("Error: {}".format(e))
     sys.exit(1)

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -62,7 +62,7 @@ try:
     try:
         sys.exit(phase())
     except Exception as e:
-        event["exception"] = e
+        event["exception"] = "{0}".format(e)
         code = 1
     except SystemExit as e:
         code = e.code

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -57,9 +57,12 @@ try:
         "core_path": os.environ["PYTHONPATH"],
     }
     try:
-        code = phase()
+        sys.exit(phase())
     except Exception as e:
         event["exception"] = e
+        code = 1
+    except SystemExit as e:
+        code = e.code
     finally:
         event["exit"] = code
         event["ended_at"] = make_utc_datetime_rfc3339()

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -4,6 +4,7 @@ import sys
 from insights import package_info
 
 import metrics
+import utc
 
 try:
     try:
@@ -27,31 +28,9 @@ try:
     except:
         machine_id = "00000000-0000-0000-0000-000000000000"
 
-    class UTC(datetime.tzinfo):
-        """
-        UTC is a concrete subclass of datetime.tzinfo representing the UTC
-        time zone.
-        """
-
-        def utcoffset(self, dt):
-            return datetime.timedelta(0)
-
-        def tzname(self, dt):
-            return "UTC"
-
-        def dst(self, dt):
-            return datetime.timedelta(0)
-
-    def make_utc_datetime_rfc3339():
-        return (
-            datetime.datetime.utcnow()
-            .replace(microsecond=0, tzinfo=UTC())
-            .isoformat("T")
-        )
-
     event = {
         "phase": os.environ["INSIGHTS_PHASE"],
-        "started_at": make_utc_datetime_rfc3339(),
+        "started_at": utc.make_utc_datetime_rfc3339(),
         "exit": code,
         "exception": None,
         "ended_at": None,
@@ -68,7 +47,7 @@ try:
         code = e.code
     finally:
         event["exit"] = code
-        event["ended_at"] = make_utc_datetime_rfc3339()
+        event["ended_at"] = utc.make_utc_datetime_rfc3339()
         metrics_client.post(event)
         sys.exit(code)
 except KeyboardInterrupt:

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -21,8 +21,11 @@ try:
         config_file="/etc/insights-client/insights-client.conf",
     )
     code = 0
-    with open("/etc/insights-client/machine-id") as f:
-        machine_id = f.read()
+    try:
+        with open("/etc/insights-client/machine-id") as f:
+            machine_id = f.read()
+    except:
+        machine_id = "00000000-0000-0000-0000-000000000000"
 
     class UTC(datetime.tzinfo):
         """

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -74,5 +74,5 @@ try:
 except KeyboardInterrupt:
     sys.exit(1)
 except Exception as e:
-    print("Error: {}".format(e))
+    print("Error: {0}".format(e))
     sys.exit(1)

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -1,6 +1,10 @@
 import os
 import sys
 
+from insights import package_info
+
+import metrics
+
 try:
     try:
         from insights.client.phase import v1 as client
@@ -11,6 +15,53 @@ try:
         )
 
     phase = getattr(client, os.environ["INSIGHTS_PHASE"])
-    sys.exit(phase())
+    metrics_client = metrics.MetricsHTTPClient(
+        "/etc/pki/consumer/cert.pem", "/etc/pki/consumer/key.pem"
+    )
+    code = 0
+    with open("/etc/insights-client/machine-id") as f:
+        machine_id = f.read()
+
+    class UTC(datetime.tzinfo):
+        """
+        UTC is a concrete subclass of datetime.tzinfo representing the UTC
+        time zone.
+        """
+
+        def utcoffset(self, dt):
+            return datetime.timedelta(0)
+
+        def tzname(self, dt):
+            return "UTC"
+
+        def dst(self, dt):
+            return datetime.timedelta(0)
+
+    def make_utc_datetime_rfc3339():
+        return (
+            datetime.datetime.utcnow()
+            .replace(microsecond=0, tzinfo=UTC())
+            .isoformat("T")
+        )
+
+    event = {
+        "phase": os.environ["INSIGHTS_PHASE"],
+        "started_at": make_utc_datetime_rfc3339(),
+        "exit": code,
+        "exception": None,
+        "ended_at": None,
+        "machine_id": machine_id,
+        "core_version": package_info["VERSION"],
+        "core_path": os.environ["PYTHONPATH"],
+    }
+    try:
+        code = phase()
+    except Exception as e:
+        event["exception"] = e
+    finally:
+        event["exit"] = code
+        event["ended_at"] = make_utc_datetime_rfc3339()
+        metrics_client.post(event)
+        sys.exit(code)
 except KeyboardInterrupt:
     sys.exit(1)

--- a/src/insights_client/utc.py
+++ b/src/insights_client/utc.py
@@ -1,0 +1,23 @@
+import datetime
+
+
+class UTC(datetime.tzinfo):
+    """
+    UTC is a concrete subclass of datetime.tzinfo representing the UTC
+    time zone.
+    """
+
+    def utcoffset(self, dt):
+        return datetime.timedelta(0)
+
+    def tzname(self, dt):
+        return "UTC"
+
+    def dst(self, dt):
+        return datetime.timedelta(0)
+
+
+def make_utc_datetime_rfc3339():
+    return (
+        datetime.datetime.utcnow().replace(microsecond=0, tzinfo=UTC()).isoformat("T")
+    )


### PR DESCRIPTION
This PR adds the collection of runtime metrics to the "phase runner" (`run.py`). Before each phase, an "event" object is created. The event object contains details about the phase, include start times, exit codes, exception strings, etc. It uses a specialized HTTP client (not `InsightsConnection`) so that statistics can still be reported back to the platform even in the event of a major failure of `InsightsConnection`. It keys off the RHSM server value. If it's not subscription.rhsm.redhat.com, the base URL, authentication scheme and API path prefix are configured to the "Satellite" values. If the RHSM server value is subscription.rhsm.redhat.com, then it examines the insights-client.conf authmethod value, setting up the base URL, authentication, and API path prefix values for either certificate or basic authentication.

**Note**: ~The `default` test will fail until #120 is merged; the `private-rhel-8.3.0` dist-git branch we use to build the RPM from is already updated to expect files that *are* present in #120, but that are absent in this PR. Merging #120 onto master, and then rebasing this PR on top of master will make that pipeline start passing.~