### PR TITLE
constants: Add location variables to generated constants

### DIFF
--- a/src/insights_client/Makefile.am
+++ b/src/insights_client/Makefile.am
@@ -16,6 +16,15 @@ CLEANFILES = constants.py
 	$(AM_V_GEN) $(SED) \
 		-e 's,[@]PACKAGE_VERSION[@],$(PACKAGE_VERSION),g' \
 		-e 's,[@]PACKAGE[@],$(PACKAGE),g' \
+		-e 's,[@]PREFIX[@],$(prefix),g' \
+		-e 's,[@]BINDIR[@],$(bindir),g' \
+		-e 's,[@]SBINDIR[@],$(sbindir),g' \
+		-e 's,[@]LIBEXECDIR[@],$(libexecdir),g' \
+		-e 's,[@]DATAROOTDIR[@],$(datarootdir),g' \
+		-e 's,[@]DATADIR[@],$(datadir),g' \
+		-e 's,[@]SYSCONFDIR[@],$(sysconfdir),g' \
+		-e 's,[@]LOCALSTATEDIR[@],$(localstatedir),g' \
+		-e 's,[@]DOCDIR[@],$(docdir),g' \
 		$< > $@.tmp && mv $@.tmp $@
 
 SUBDIRS = tests

--- a/src/insights_client/constants.py.in
+++ b/src/insights_client/constants.py.in
@@ -2,7 +2,19 @@
 Constants
 """
 
+APP_NAME = '@PACKAGE@'
+VERSION = '@PACKAGE_VERSION@'
+PREFIX = '@PREFIX@'
+BINDIR = '@BINDIR@'
+SBINDIR = '@SBINDIR@'
+LIBEXECDIR = '@LIBEXECDIR@'
+DATAROOTDIR = '@DATAROOTDIR@'
+DATADIR = '@DATADIR@'
+SYSCONFDIR = '@SYSCONFDIR@'
+LOCALSTATEDIR = '@LOCALSTATEDIR@'
+DOCDIR = '@DOCDIR@'
+
 
 class InsightsConstants(object):
-    app_name = '@PACKAGE@'
-    version = '@PACKAGE_VERSION@'
+    app_name = APP_NAME
+    version = VERSION


### PR DESCRIPTION
Add the common location variables, as generated by the `configure` script, to the generated constants.py file, so they are accessible within the program. This is the first in a long process of updating `insights-core.client.constants` to be able to use properly portable filesystem paths. Sadly, nothing in `insights-core` can use these paths until an RPM containing the generated constants file has been released on all RHEL distributions.