### PR TITLE
Fix motd.d management

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,10 +21,6 @@ AC_PATH_PROG([WGET], [wget])
 AS_IF([test -z "$WGET"],[
     AC_MSG_ERROR([wget is missing from your system...])
 ])
-AC_PATH_PROG([STRINGS], [strings])
-AS_IF([test -z "$STRINGS"],[
-    AC_MSG_ERROR([strings is missing from your system...])
-])
 AC_PATH_PROG([TIMEOUT], [timeout])
 AS_IF([test -z "$TIMEOUT"],[
     AC_MSG_ERROR([timeout is missing from your system...])
@@ -55,20 +51,6 @@ AS_IF([test x"$HAVE_PYMOD_RHSM" = x"no"],[
 dnl Set up required systemd directories and automake variables
 SYSTEMD_SYSTEMUNITDIR
 SYSTEMD_SYSTEMPRESETDIR
-
-dnl Check for version of pam_motd.so that supports motd.d.
-dnl This is ugly but seems to be the most reliable way to detect which version
-dnl of PAM is available on the system.
-AC_MSG_CHECKING([for motd_d support])
-have_motdd=no
-if test -f $libdir/security/pam_motd.so; then
-    $STRINGS $libdir/security/pam_motd.so | grep -q "motd_dir="
-    if test $? -eq 0; then
-        have_motdd=yes
-    fi
-fi
-AC_MSG_RESULT([$have_motdd])
-AM_CONDITIONAL([HAVE_MOTDD], [test x"$have_motdd" = x"yes"])
 
 dnl Optionally install a systemd unit to automatically register insights-client
 dnl when it detects an RHSM subscription.

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -6,14 +6,11 @@ dist_pkgsysconf_DATA = \
 	.fallback.json.asc \
 	cert-api.access.redhat.com.pem \
 	insights-client.conf \
+	insights-client.motd \
 	redhattools.pub.gpg \
 	rpm.egg \
 	rpm.egg.asc \
 	$(NULL)
-
-if HAVE_MOTDD
-pkgsysconf_DATA = insights-client.motd
-endif
 
 AM_V_DL = $(am__v_DL_$(V))
 am__v_DL_ = $(am__v_DL_$(AM_DEFAULT_VERBOSITY))
@@ -26,8 +23,6 @@ rpm.egg.asc:
 	$(AM_V_DL) $(WGET) --no-verbose --output-document $@ https://api.access.redhat.com/r/insights/v1/static/core/insights-core.egg.asc
 
 CLEANFILES = rpm.egg rpm.egg.asc
-
-EXTRA_DIST = insights-client.motd
 
 if WITH_SYSTEMDSYSTEMUNITDIR
 SYSTEMDDIR = systemd

--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -24,6 +24,7 @@ UNREGISTERED_FILE = "/etc/insights-client/.unregistered"
 STABLE_EGG = "/var/lib/insights/last_stable.egg"
 RPM_EGG = "/etc/insights-client/rpm.egg"
 MOTD_FILE = "/etc/motd.d/insights-client"
+MOTD_SRC = "/etc/insights-client/insights-client.motd"
 
 logger = logging.getLogger(__name__)
 
@@ -141,14 +142,17 @@ def update_motd_message():
     /etc/motd.d/insights-client at an empty file.
 
     It is intentional that the message does not reappear if a system is then
-    unregistered.
+    unregistered. Only if both the unregistered and the registered stamp files
+    do not exist is an motd symlink created.
     """
     try:
-        if os.path.exists(os.path.dirname(MOTD_FILE)) and (
-            os.path.isfile(REGISTERED_FILE) or os.path.isfile(UNREGISTERED_FILE)
-        ):
-            os.symlink(os.devnull, MOTD_FILE + ".tmp")
-            os.rename(MOTD_FILE + ".tmp", MOTD_FILE)
+        if os.path.exists(os.path.dirname(MOTD_FILE)):
+            if (os.path.isfile(REGISTERED_FILE) or os.path.isfile(UNREGISTERED_FILE)):
+                os.symlink(os.devnull, MOTD_FILE + ".tmp")
+                os.rename(MOTD_FILE + ".tmp", MOTD_FILE)
+            else:
+                os.symlink(MOTD_SRC, MOTD_FILE + ".tmp")
+                os.rename(MOTD_FILE + ".tmp", MOTD_FILE)
     except OSError as e:
         # In the case of multiple processes
         logger.debug("Could not modify motd.d file: %s", str(e))

--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -140,7 +140,7 @@ def update_motd_message():
     It is intentional that message does not reappear if a system is then unregistered.
     """
     try:
-        if os.path.isfile(NEW_EGG):
+        if os.path.exists(os.path.dirname(MOTD_FILE)) and os.path.isfile(NEW_EGG):
             os.symlink(os.devnull, MOTD_FILE + ".tmp")
             os.rename(MOTD_FILE + ".tmp", MOTD_FILE)
     except OSError as e:


### PR DESCRIPTION
Currently, insights-client uses the presence of newest.egg to decide whether to preserve or remove the /etc/motd.d/insights-client snippet. For clients where auto_update is disabled, the newest.egg never gets created, leading to a false claim from the motd stating that the host is not registered, when in reality, it is.

This PR changes the logic of the `update_motd_message` function to use the registration stamp files. If either .registered or .unregistered exist, the symlink in `/etc/motd.d/insights-client` is updated to point to `/dev/null`. Additionally, the function will update the symlink to point to the actual snippet file (`/etc/insights-client/insights-client.motd`) if both registration stamp files do not exist. This enables us to make a single invocation of the function during the RPM `%post` scriptlet that sets up the motd symlink based on local machine state.