### PR TITLE
Make calls to metrics_client.post non-fatal

### DIFF
--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -19,7 +19,7 @@ class MetricsHTTPClient(requests.Session):
         cert_file=None,
         key_file=None,
         base_url=None,
-        config_file=None,
+        config_file="/etc/insights-client/insights-client.conf",
         rhsm_config_file="/etc/rhsm/rhsm.conf",
     ):
         """

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -44,10 +44,13 @@ try:
     finally:
         event["exit"] = code
         event["ended_at"] = utc.make_utc_datetime_rfc3339()
-        metrics_client.post(event)
+        try:
+            metrics_client.post(event)
+        except OSError as e:
+            print("Error: Could not submit event: {0}".format(e))
         sys.exit(code)
 except KeyboardInterrupt:
     sys.exit(1)
 except Exception as e:
-    print("Error: {0}".format(e))
+    print("Fatal: {0}".format(e))
     sys.exit(1)

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -16,11 +16,7 @@ try:
         )
 
     phase = getattr(client, os.environ["INSIGHTS_PHASE"])
-    metrics_client = metrics.MetricsHTTPClient(
-        cert_file="/etc/pki/consumer/cert.pem",
-        key_file="/etc/pki/consumer/key.pem",
-        config_file="/etc/insights-client/insights-client.conf",
-    )
+    metrics_client = metrics.MetricsHTTPClient()
     code = 0
     try:
         with open("/etc/insights-client/machine-id") as f:


### PR DESCRIPTION
If a machine is not registered with RHSM (i.e. `/etc/pki/consumer/cert.pem` does not exist), the `MetricsHTTPClient` still configures itself to use the certificates, but then fails fatally when it cannot read that file. This PR makes the `metrics_client.post` call non-fatal; instead an error is printed but the phase continues.