### PR TITLE
remove root check

### DIFF
--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -163,9 +163,6 @@ def _main():
     attempt to collect and upload with new, then current, then rpm
     if an egg fails a phase never try it again
     """
-    if os.getuid() != 0:
-        sys.exit('Insights client must be run as root.')
-
     # sort rpm and stable eggs after verification
     validated_eggs = sorted_eggs(
         list(filter(gpg_validate, [STABLE_EGG, RPM_EGG])))

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -33,6 +33,19 @@ class MetricsHTTPClient(requests.Session):
         cfg = configparser.RawConfigParser()
         cfg.read(config_file)
 
+        if os.getuid() != 0:
+            # force basic auth for non-root
+            self.base_url = "cloud.redhat.com"
+            self.port = 443
+            try:
+                u = cfg.get("insights-client", "username")
+                p = cfg.get("insights-client", "password")
+            except:
+                print("Could not read username and password from %s" % config_file)
+            self.auth = (u, p)
+            self.api_prefix = "/api"
+            return
+
         rhsm_cfg = configparser.ConfigParser()
         rhsm_cfg.read(rhsm_config_file)
 

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -42,6 +42,8 @@ class MetricsHTTPClient(requests.Session):
                 p = cfg.get("insights-client", "password")
             except:
                 print("Could not read username and password from %s" % config_file)
+                u = None
+                p = None
             self.auth = (u, p)
             self.api_prefix = "/api"
             return

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -15,8 +15,18 @@ try:
             % (os.environ["INSIGHTS_PHASE"], os.environ["PYTHONPATH"], e)
         )
 
+    try:
+        # import config file constant so it can be read for a non-root user
+        # TODO: prefer --conf option
+        # TODO: autogenerate local user config file
+        from insights.client.constants import InsightsConstants
+        default_conf_file = InsightsConstants.default_conf_file
+    except ImportError as e:
+        print('Error importing constants from insights-core, using defaults.')
+        default_conf_file = "/etc/insights-client/insights-client.conf"
+
     phase = getattr(client, os.environ["INSIGHTS_PHASE"])
-    metrics_client = metrics.MetricsHTTPClient()
+    metrics_client = metrics.MetricsHTTPClient(config_file=default_conf_file)
     code = 0
     try:
         with open("/etc/insights-client/machine-id") as f:

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -18,7 +18,6 @@ try:
     try:
         # import config file constant so it can be read for a non-root user
         # TODO: prefer --conf option
-        # TODO: autogenerate local user config file
         from insights.client.constants import InsightsConstants
         default_conf_file = InsightsConstants.default_conf_file
     except ImportError as e:


### PR DESCRIPTION
Remove the root check in the client. Note that the GPG checks on the eggs will still fail as non-root until we change the permissions on the `redhattools.pub.gpg` file we ship in the RPM.