### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,6 @@ python:
     - "2.7"
 install: pip install flake8
 script: flake8
+arch:
+  - amd64
+  - ppc64le


### PR DESCRIPTION
Hi,
I had added ppc64le architecture support on travis-ci and looks like its been successfully added. I believe it is ready for the final review and merge.

The travis ci build logs can be verified from the link below.
https://travis-ci.com/github/kishorkunal-raj/insights-client/builds/187201251
Please have a look.

Thanks!!
Kishor Kunal Raj