### PR TITLE
build: generate constants.py with SCRIPT primary

### DIFF
--- a/src/insights_client/Makefile.am
+++ b/src/insights_client/Makefile.am
@@ -11,6 +11,10 @@ nodist_insights_client_PYTHON = \
 	constants.py \
 	$(NULL)
 
+BUILT_SOURCES = \
+	constants.py \
+	$(NULL)
+
 EXTRA_DIST = constants.py.in
 CLEANFILES = constants.py
 


### PR DESCRIPTION
Files listed with the `PYTHON` primary are not subject to any build time rules. The `PYTHON` primary only does stuff during installation like byte-compile the files listed[1]. What was happening was that `constants.py` was not getting generated until necessary, and it was necessary for installation. This PR adds the `nodist_insights_client_PYTHON` sources as a `SCRIPT` primary. `SCRIPT` primaries *are* generated at build time, so this ends up generating `constants.py` earlier in the process. `SCRIPT` primaries are not distributed by default, so it doesn't need to be listed as `nodist`, and it's already not distributed via `nodist_insights_client_PYTHON`.

1: https://www.gnu.org/software/automake/manual/html_node/Python.html
2: https://www.gnu.org/software/automake/manual/html_node/Scripts.html