### PR TITLE
fix: print warning to stderr

### DIFF
--- a/src/redhat-access-insights.in
+++ b/src/redhat-access-insights.in
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-echo "WARNING: $(basename "$0") is deprecated and will be removed in a future release; use 'insights-client' instead."
+>&2 echo "WARNING: $(basename "$0") is deprecated and will be removed in a future release; use 'insights-client' instead."
 sleep 3
 exec @bindir@/insights-client "$@"


### PR DESCRIPTION
Printing the warning to stdout breaks some downstream tooling that
assumes the output of insights-client is a certain data format (such as
JSON). Instead, the warning should be printed to stderr.

Fixes: RHCLOUD-10655, RHBZ#1896547
Signed-off-by: Link Dupont <link@sub-pop.net>