### PR TITLE
Check-in SystemD service

### DIFF
--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -1,6 +1,7 @@
 dist_systemdsystemunit_DATA = \
 	insights-client.service \
 	insights-client.timer \
+	insights-client-checkin.timer \
 	$(NULL)
 
 systemdsystemunit_DATA = \

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -25,7 +25,7 @@ endif
 
 CLEANFILES = $(systemdsystemunit_DATA)
 EXTRA_DIST = \
-	insights-checkin.service.in \
+	insights-client-checkin.service.in \
 	insights-client-results.service.in \
 	insights-client-results.path.in \
 	insights-register.service.in \

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -4,6 +4,7 @@ dist_systemdsystemunit_DATA = \
 	$(NULL)
 
 systemdsystemunit_DATA = \
+	insights-client-checkin.service \
 	insights-client-results.service \
 	insights-client-results.path \
 	$(NULL)

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -25,6 +25,7 @@ endif
 
 CLEANFILES = $(systemdsystemunit_DATA)
 EXTRA_DIST = \
+	insights-checkin.service.in \
 	insights-client-results.service.in \
 	insights-client-results.path.in \
 	insights-register.service.in \

--- a/data/systemd/insights-checkin.service.in
+++ b/data/systemd/insights-checkin.service.in
@@ -1,0 +1,21 @@
+# This file is part of insights-client.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/insights-register.service.d/override.conf. Put the desired
+# overrides in that file and reload systemd. The next time this service is run
+# (either manually or via a systemd timer), the overridden values will be in
+# effect.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Automatically Register with Red Hat Insights
+Documentation=man:insights-client(8)
+After=network-online.target
+
+[Service]
+Type=simple
+RemainAfterExit=no
+ExecStart=@bindir@/insights-client --checkin
+Restart=no

--- a/data/systemd/insights-client-checkin.service.in
+++ b/data/systemd/insights-client-checkin.service.in
@@ -2,20 +2,20 @@
 #
 # Any changes made to this file will be overwritten during a software update. To
 # override a parameter in this file, create a drop-in file, typically located at
-# /etc/systemd/system/insights-register.service.d/override.conf. Put the desired
-# overrides in that file and reload systemd. The next time this service is run
-# (either manually or via a systemd timer), the overridden values will be in
-# effect.
+# /etc/systemd/system/insights-client-results.service.d/override.conf. Put the
+# desired overrides in that file and reload systemd. The next time this service
+# is run (either manually or via another systemd unit), the overridden values
+# will be in effect.
 #
 # For more information about systemd drop-in files, see systemd.unit(5).
 
 [Unit]
-Description=Automatically Register with Red Hat Insights
+Description=Check-in with the platform
 Documentation=man:insights-client(8)
 After=network-online.target
 
 [Service]
-Type=simple
+Type=oneshot
 RemainAfterExit=no
 ExecStart=@bindir@/insights-client --checkin
 Restart=no

--- a/data/systemd/insights-client-checkin.service.in
+++ b/data/systemd/insights-client-checkin.service.in
@@ -13,6 +13,7 @@
 Description=Check-in with the platform
 Documentation=man:insights-client(8)
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot

--- a/data/systemd/insights-client-checkin.timer
+++ b/data/systemd/insights-client-checkin.timer
@@ -1,0 +1,22 @@
+# This file is part of insights-client.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/insights-client.timer.d/override.conf. Put the desired
+# overrides in that file, reload systemd and restart this timer.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Check-in with the platform timer
+Documentation=man:insights-client(8)
+After=network-online.target
+Wants=network-online.target
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+RandomizedDelaySec=600
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Created a new service for the hourly checkin and a corresponding timer unit. This PR only introduces the units, but not a mechanism to enable them upon registration. To verify their workings, launch them manually with _systemctl_ after running _make install_. Use SystemD drop-ins to change any settings.