### PR TITLE
Remove egg is file condition

### DIFF
--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -97,7 +97,7 @@ def run_phase(phase, client, validated_eggs):
     all_eggs = [ENV_EGG, NEW_EGG] + validated_eggs
 
     for i, egg in enumerate(all_eggs):
-        if egg is None or not os.path.isfile(egg):
+        if egg is None:
             if debug:
                 log("Egg does not exist: %s" % egg)
             continue


### PR DESCRIPTION
The insights package imported to run a Phase does not have to be an egg file. It can simply be a folder with a cloned copy of the [_insights-core_](https://github.com/RedHatInsights/insights-core/) repository. This is very common in development environments and allows to live edit and use the Core files by the Client without rebuilding the egg by making a zip file.

No tests added as this egg selecting machinery is already completely untested and adding one would be non-trivial and inconsistent.

Steps to reproduce:

1. Run the client with `EGG=/path/to/insights-core BYPASS_GPG=True insights-client --no-gpg`
2. See that the code in the folder is picked and used as the env egg, allowing for immediate edit and use of the core files without rebuilding the zip file.