### PR TITLE
Add systemd unit file for insights-client-boot service

### DIFF
--- a/data/systemd/insights-client-boot.service
+++ b/data/systemd/insights-client-boot.service
@@ -24,7 +24,7 @@ TasksMax=300
 BlockIOWeight=100
 ExecStartPost=-/bin/bash -c "echo 2G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.memsw.limit_in_bytes"
 ExecStartPost=-/bin/bash -c "echo 1G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.soft_limit_in_bytes"
-ExecStartPost=-rm /etc/insights-client/.run_insights_client_next_boot
+ExecStartPost=rm -f /etc/insights-client/.run_insights_client_next_boot
 
 [Install]
 Wants=multi-user.target

--- a/data/systemd/insights-client-boot.service
+++ b/data/systemd/insights-client-boot.service
@@ -21,6 +21,7 @@ WatchdogSec=900
 CPUQuota=30%
 MemoryHigh=1G
 MemoryMax=2G
+MemoryLimit=2G # For compatability with RHEL7
 TasksMax=300
 BlockIOWeight=100
 ExecStartPost=/bin/rm /etc/insights-client/.run_insights_client_next_boot

--- a/data/systemd/insights-client-boot.service
+++ b/data/systemd/insights-client-boot.service
@@ -19,7 +19,6 @@ ExecStart=/usr/bin/insights-client --retry 3
 Restart=no
 WatchdogSec=900
 CPUQuota=30%
-MemoryLimit=2G
 MemoryHigh=1G
 MemoryMax=2G
 TasksMax=300

--- a/data/systemd/insights-client-boot.service
+++ b/data/systemd/insights-client-boot.service
@@ -1,0 +1,30 @@
+# This file is part of insights-client.
+#
+# Any changes made to this file will be overwritten during a software update. To
+# override a parameter in this file, create a drop-in file, typically located at
+# /etc/systemd/system/insights-client-boot.service.d/override.conf Put the desired
+# overrides in that file and reload systemd.
+#
+# For more information about systemd drop-in files, see systemd.unit(5).
+
+[Unit]
+Description=Run Insights Client at boot
+Documentation=man:insights-client(8)
+After=network.target
+ConditionPathExists=/etc/insights-client/.run_insights_client_next_boot
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/insights-client --retry 3
+Restart=no
+WatchdogSec=900
+CPUQuota=30%
+MemoryLimit=2G
+TasksMax=300
+BlockIOWeight=100
+ExecStartPost=-/bin/bash -c "echo 2G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.memsw.limit_in_bytes"
+ExecStartPost=-/bin/bash -c "echo 1G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.soft_limit_in_bytes"
+ExecStartPost=-rm /etc/insights-client/.run_insights_client_next_boot
+
+[Install]
+Wants=multi-user.target

--- a/data/systemd/insights-client-boot.service
+++ b/data/systemd/insights-client-boot.service
@@ -20,11 +20,11 @@ Restart=no
 WatchdogSec=900
 CPUQuota=30%
 MemoryLimit=2G
+MemoryHigh=1G
+MemoryMax=2G
 TasksMax=300
 BlockIOWeight=100
-ExecStartPost=-/bin/bash -c "echo 2G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.memsw.limit_in_bytes"
-ExecStartPost=-/bin/bash -c "echo 1G >/dev/null 2>&1 > /sys/fs/cgroup/memory/system.slice/insights-client.service/memory.soft_limit_in_bytes"
-ExecStartPost=rm -f /etc/insights-client/.run_insights_client_next_boot
+ExecStartPost=/bin/rm /etc/insights-client/.run_insights_client_next_boot
 
 [Install]
 Wants=multi-user.target


### PR DESCRIPTION
Based on conversations with @subpop.  This PR will add a systemd unit file that will _upon declaration of a file run_insights_client_next_boot_ will run the insights client on the next boot of the host node.  This will be triggered by playbooks created by remediations that are specified with the `localhost` tag.

See Corresponding Remediations JIRA:  https://github.com/RedHatInsights/insights-remediations/pull/12