### PR TITLE
Ultralight check-in ./configure option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,6 +60,14 @@ AC_ARG_ENABLE([auto-registration],
     [auto_registration=${enableval}], [auto_registration=no])
 AM_CONDITIONAL([ENABLE_AUTO_REGISTRATION], [test "x${auto_registration}" = xyes])
 
+dnl Optionally install a systemd unit to check-in hourly with the Inventory with
+dnl a ultralight POST request.
+AC_ARG_ENABLE([checkin],
+    [AS_HELP_STRING([--enable-checkin],
+        [enable hourly check-in @<:@default: no@:>@])],
+    [checkin=${enableval}], [checkin=no])
+AM_CONDITIONAL([ENABLE_CHECKIN], [test "x${checkin}" = xyes])
+
 AC_CONFIG_FILES([
     Makefile
     data/Makefile

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -1,11 +1,9 @@
 dist_systemdsystemunit_DATA = \
 	insights-client.service \
 	insights-client.timer \
-	insights-client-checkin.timer \
 	$(NULL)
 
 systemdsystemunit_DATA = \
-	insights-client-checkin.service \
 	insights-client-results.service \
 	insights-client-results.path \
 	$(NULL)
@@ -25,16 +23,7 @@ systemdsystempreset_DATA += \
 	$(NULL)
 endif
 
-if ENABLE_CHECKIN
-systemdsystemunit_DATA += \
-	insights-client-checkin.service \
-	insights-client-checkin.timer \
-	$(NULL)
-endif
-
-CLEANFILES = $(systemdsystemunit_DATA)
 EXTRA_DIST = \
-	insights-client-checkin.service.in \
 	insights-client-results.service.in \
 	insights-client-results.path.in \
 	insights-register.service.in \
@@ -43,6 +32,22 @@ EXTRA_DIST = \
 	insights-unregister.path.in \
 	80-insights.preset \
 	$(NULL)
+
+if ENABLE_CHECKIN
+dist_systemdsystemunit_DATA += \
+	insights-client-checkin.timer \
+	$(NULL)
+
+systemdsystemunit_DATA += \
+	insights-client-checkin.service \
+	$(NULL)
+
+EXTRA_DIST += \
+	insights-client-checkin.service.in \
+	$(NULL)
+endif
+
+CLEANFILES = $(systemdsystemunit_DATA)
 
 %: %.in Makefile
 	$(AM_V_GEN) $(SED) \

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -29,6 +29,7 @@ if ENABLE_CHECKIN
 systemdsystemunit_DATA += \
 	insights-client-checkin.service \
 	insights-client-checkin.timer \
+	$(NULL)
 endif
 
 CLEANFILES = $(systemdsystemunit_DATA)

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -25,6 +25,12 @@ systemdsystempreset_DATA += \
 	$(NULL)
 endif
 
+if ENABLE_CHECKIN
+systemdsystemunit_DATA += \
+	insights-client-checkin.service \
+	insights-client-checkin.timer \
+endif
+
 CLEANFILES = $(systemdsystemunit_DATA)
 EXTRA_DIST = \
 	insights-client-checkin.service.in \


### PR DESCRIPTION
Added a feature flag for the ultralight check-in SystemD units _--enable-checkin_, disabled by default. This allows us to safely ship the ultralight check-in feature without enabling it.

No tests as we don’t test autotools files.

# How to test #

1. _./configure_ without the flag.
2. _make_
3. Check that _data/systemd/insights-client-checkin.service_ has not been compiled.
4. _make_ install
5. Check that neither _insights-client-checkin.service_ not _insights-client-checkin.timer_ has been installed.
6. _make clean_.
7. _./configure --enable-checkin_
8. _make_
9. Check that _data/systemd/insights-client-checkin.service_ has been compiled.
10. _make_ install
11. Check that both _insights-client-checkin.service_ and _insights-client-checkin.timer_ have been installed.
12. _make clean_.
13. Check that _data/systemd/insights-client-checkin.service_ has been cleaned.
14. _./configure --help_.
15. Check that the --enable-checkin feature flag is documented.