### PR TITLE
fix: only rewrite motd symlink if not already

### DIFF
--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -147,8 +147,9 @@ def update_motd_message():
     try:
         if os.path.exists(os.path.dirname(MOTD_FILE)):
             if (os.path.isfile(REGISTERED_FILE) or os.path.isfile(UNREGISTERED_FILE)):
-                os.symlink(os.devnull, MOTD_FILE + ".tmp")
-                os.rename(MOTD_FILE + ".tmp", MOTD_FILE)
+                if not os.path.samefile(os.devnull, MOTD_FILE):
+                    os.symlink(os.devnull, MOTD_FILE + ".tmp")
+                    os.rename(MOTD_FILE + ".tmp", MOTD_FILE)
             else:
                 os.symlink(MOTD_SRC, MOTD_FILE + ".tmp")
                 os.rename(MOTD_FILE + ".tmp", MOTD_FILE)


### PR DESCRIPTION
The motd.d symlink should not be rewritten every time insights-client runs. This breaks automation that relies on the mtime of the symlink file.

Fixes RHBZ#1945481