### PR TITLE
Various systemd/automake fixes

### DIFF
--- a/data/systemd/80-insights-register.preset
+++ b/data/systemd/80-insights-register.preset
@@ -1,0 +1,2 @@
+enable insights-register.path
+enable insights-unregister.path

--- a/data/systemd/80-insights.preset
+++ b/data/systemd/80-insights.preset
@@ -1,3 +1,1 @@
-enable insights-register.path
-enable insights-unregister.path
 enable insights-client-boot.service

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -12,17 +12,10 @@ systemdsystemunit_DATA = \
 systemdsystempreset_DATA = \
 	$(NULL)
 
-if ENABLE_AUTO_REGISTRATION
-systemdsystemunit_DATA += \
-	insights-register.service \
-	insights-register.path \
-	insights-unregister.service \
-	insights-unregister.path \
+CLEANFILES = \
+	insights-client-results.service \
+	insights-client-results.path \
 	$(NULL)
-systemdsystempreset_DATA += \
-	80-insights.preset \
-	$(NULL)
-endif
 
 EXTRA_DIST = \
 	insights-client-checkin.timer \
@@ -36,14 +29,33 @@ EXTRA_DIST = \
 	80-insights.preset \
 	$(NULL)
 
+if ENABLE_AUTO_REGISTRATION
+systemdsystemunit_DATA += \
+	insights-register.service \
+	insights-register.path \
+	insights-unregister.service \
+	insights-unregister.path \
+	$(NULL)
+systemdsystempreset_DATA += \
+	80-insights.preset \
+	$(NULL)
+CLEANFILES += \
+	insights-register.service \
+	insights-register.path \
+	insights-unregister.service \
+	insights-unregister.path \
+	$(NULL)
+endif
+
 if ENABLE_CHECKIN
 systemdsystemunit_DATA += \
 	insights-client-checkin.timer \
 	insights-client-checkin.service \
 	$(NULL)
+CLEANFILES += \
+	insights-client-checkin.service \
+	$(NULL)
 endif
-
-CLEANFILES = $(systemdsystemunit_DATA)
 
 %: %.in Makefile
 	$(AM_V_GEN) $(SED) \

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -25,6 +25,8 @@ systemdsystempreset_DATA += \
 endif
 
 EXTRA_DIST = \
+	insights-client-checkin.timer \
+	insights-client-checkin.service.in \
 	insights-client-results.service.in \
 	insights-client-results.path.in \
 	insights-register.service.in \
@@ -35,16 +37,9 @@ EXTRA_DIST = \
 	$(NULL)
 
 if ENABLE_CHECKIN
-dist_systemdsystemunit_DATA += \
-	insights-client-checkin.timer \
-	$(NULL)
-
 systemdsystemunit_DATA += \
+	insights-client-checkin.timer \
 	insights-client-checkin.service \
-	$(NULL)
-
-EXTRA_DIST += \
-	insights-client-checkin.service.in \
 	$(NULL)
 endif
 

--- a/data/systemd/Makefile.am
+++ b/data/systemd/Makefile.am
@@ -12,6 +12,10 @@ systemdsystemunit_DATA = \
 systemdsystempreset_DATA = \
 	$(NULL)
 
+dist_systemdsystempreset_DATA = \
+	80-insights.preset \
+	$(NULL)
+
 CLEANFILES = \
 	insights-client-results.service \
 	insights-client-results.path \
@@ -26,7 +30,7 @@ EXTRA_DIST = \
 	insights-register.path.in \
 	insights-unregister.service.in \
 	insights-unregister.path.in \
-	80-insights.preset \
+	80-insights-register.preset \
 	$(NULL)
 
 if ENABLE_AUTO_REGISTRATION
@@ -37,7 +41,7 @@ systemdsystemunit_DATA += \
 	insights-unregister.path \
 	$(NULL)
 systemdsystempreset_DATA += \
-	80-insights.preset \
+	80-insights-register.preset \
 	$(NULL)
 CLEANFILES += \
 	insights-register.service \


### PR DESCRIPTION
The systemd data Makefile.am needed a bit of cleanup.

* Fixed a bug where the insights-client-checkin.service.in file was missing from the distribution tarball.
* Refactor the CLEANFILES variable to explicitly list all the files that should be cleaned up by the clean target.
* Create two preset files: one is always installed and includes insights-client-boot.service. The other is installed only if the software is configured with --enable-auto-registration, and includes the insights-register.path and insights-unregister.path units.

Fixes: RHBZ#1951750