### PR TITLE
Make metrics usable without RHSM

### DIFF
--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -9,10 +9,13 @@ AUTH_METHOD_CERT = "CERT"
 
 
 def _proxy_settings(rhsm_config):
-    hostname = rhsm_config.get("server", "proxy_hostname").strip()
-    port = rhsm_config.get("server", "proxy_port").strip()
-    user = rhsm_config.get("server", "proxy_user").strip()
-    password = rhsm_config.get("server", "proxy_password").strip()
+    try:
+        hostname = rhsm_config.get("server", "proxy_hostname").strip()
+        port = rhsm_config.get("server", "proxy_port").strip()
+        user = rhsm_config.get("server", "proxy_user").strip()
+        password = rhsm_config.get("server", "proxy_password").strip()
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        return None
 
     if not hostname:
         return None

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -14,22 +14,19 @@ def _proxy_settings(rhsm_config):
             "user": None,
             "password": None}
 
-    try:
-        for key in conf:
-            try:
-                conf[key] = rhsm_config.get("server", "proxy_" + key).strip()
-                if key == "hostname" and conf[key] is None:
-                    # hostname is the only required value. return None if empty
-                    return None
-            except configparser.NoOptionError:
-                if key == "hostname":
-                    return None
-    except configparser.NoSectionError:
-        return None
+    for key in conf:
+        try:
+            conf[key] = rhsm_config.get("server", "proxy_" + key).strip() or None
+        except configparser.NoSectionError:
+            return None
+        except configparser.NoOptionError:
+            pass
+        if key == "hostname" and not conf[key]:
+            # hostname is the only required value. return None if empty
+            return None
 
     auth = "%s:%s@" % (conf["user"], conf["password"]) if conf["user"] and conf["password"] else ""
-    path = "%s:%s" % (conf["hostname"], conf["port"] if conf["port"] else "")
-    proxy = "http://%s%s" % (auth, path)
+    proxy = "http://%s%s:%s" % (auth, conf["hostname"], conf["port"] or "")
 
     return {"https": proxy}
 

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -80,6 +80,8 @@ class MetricsHTTPClient(requests.Session):
                 is_satellite = True
             else:
                 is_satellite = False
+
+        if not is_satellite:
             try:
                 auth_method = cfg.get("insights-client", "authmethod")
             except configparser.NoOptionError:

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -11,13 +11,12 @@ AUTH_METHOD_CERT = "CERT"
 def _proxy_settings(rhsm_config):
     try:
         hostname = rhsm_config.get("server", "proxy_hostname").strip()
+        if not hostname:
+            return None
         port = rhsm_config.get("server", "proxy_port").strip()
         user = rhsm_config.get("server", "proxy_user").strip()
         password = rhsm_config.get("server", "proxy_password").strip()
     except (configparser.NoSectionError, configparser.NoOptionError):
-        return None
-
-    if not hostname:
         return None
 
     auth = "%s:%s@" % (user, password) if user and password else ""
@@ -55,10 +54,10 @@ class MetricsHTTPClient(requests.Session):
         rhsm_cfg.read(rhsm_config_file)
 
         try:
-            rhsm_server_hostname = rhsm_cfg.get("server", "hostname")
-            rhsm_server_port = rhsm_cfg.get("server", "port")
-            rhsm_rhsm_repo_ca_cert = rhsm_cfg.get("rhsm", "repo_ca_cert")
-            rhsm_rhsm_consumerCertDir = rhsm_cfg.get("rhsm", "consumerCertDir")
+            rhsm_server_hostname = rhsm_cfg.get("server", "hostname").strip()
+            rhsm_server_port = rhsm_cfg.get("server", "port").strip()
+            rhsm_rhsm_repo_ca_cert = rhsm_cfg.get("rhsm", "repo_ca_cert").strip()
+            rhsm_rhsm_consumerCertDir = rhsm_cfg.get("rhsm", "consumerCertDir").strip()
         except (configparser.NoSectionError, configparser.NoOptionError):
             # cannot read RHSM conf, go straight to insights-client conf parsing
             # set is_satellite=False to enter the insights-client.conf parsing block

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -113,7 +113,6 @@ class MetricsHTTPClient(requests.Session):
         else:
             self.proxies = None
 
-
     def post(self, event):
         """
         post sends `event` to the Insights Platform.

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -59,7 +59,11 @@ class MetricsHTTPClient(requests.Session):
             rhsm_server_port = rhsm_cfg.get("server", "port")
             rhsm_rhsm_repo_ca_cert = rhsm_cfg.get("rhsm", "repo_ca_cert")
             rhsm_rhsm_consumerCertDir = rhsm_cfg.get("rhsm", "consumerCertDir")
-
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            # cannot read RHSM conf, go straight to insights-client conf parsing
+            # set is_satellite=False to enter the insights-client.conf parsing block
+            is_satellite = False
+        else:
             if cert_file is None:
                 cert_file = os.path.join(rhsm_rhsm_consumerCertDir, "cert.pem")
             if key_file is None:
@@ -76,12 +80,6 @@ class MetricsHTTPClient(requests.Session):
                 is_satellite = True
             else:
                 is_satellite = False
-        except (configparser.NoSectionError, configparser.NoOptionError):
-            # cannot read RHSM conf, go straight to insights-client conf parsing
-            # set is_satellite=False to enter the insights-client.conf parsing block
-            is_satellite = False
-
-        if not is_satellite:
             try:
                 auth_method = cfg.get("insights-client", "authmethod")
             except configparser.NoOptionError:

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -3,9 +3,12 @@ import sys
 
 from insights import package_info
 
+import logging
 import metrics
 import utc
 from requests import ConnectionError
+
+logger = logging.getLogger(__name__)
 
 try:
     try:
@@ -47,8 +50,8 @@ try:
         event["ended_at"] = utc.make_utc_datetime_rfc3339()
         try:
             metrics_client.post(event)
-        except (OSError, ConnectionError) as e:
-            print("Error: Could not submit event: {0}".format(e))
+        except (OSError, IOError, ConnectionError) as e:
+            logger.debug("Could not submit event: {0}".format(e))
         sys.exit(code)
 except KeyboardInterrupt:
     sys.exit(1)

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -6,7 +6,6 @@ from insights import package_info
 import logging
 import metrics
 import utc
-from requests import ConnectionError
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +49,7 @@ try:
         event["ended_at"] = utc.make_utc_datetime_rfc3339()
         try:
             metrics_client.post(event)
-        except (OSError, IOError, ConnectionError) as e:
+        except (OSError, IOError) as e:
             logger.debug("Could not submit event: {0}".format(e))
         sys.exit(code)
 except KeyboardInterrupt:

--- a/src/insights_client/run.py
+++ b/src/insights_client/run.py
@@ -5,6 +5,7 @@ from insights import package_info
 
 import metrics
 import utc
+from requests import ConnectionError
 
 try:
     try:
@@ -46,7 +47,7 @@ try:
         event["ended_at"] = utc.make_utc_datetime_rfc3339()
         try:
             metrics_client.post(event)
-        except OSError as e:
+        except (OSError, ConnectionError) as e:
             print("Error: Could not submit event: {0}".format(e))
         sys.exit(code)
 except KeyboardInterrupt:

--- a/src/insights_client/tests/test_metrics.py
+++ b/src/insights_client/tests/test_metrics.py
@@ -104,7 +104,7 @@ def test_http_client_init_is_not_satellite(proxy_settings, config_file_factory, 
     assert metrics_client.api_prefix == "/api"
 
 @patch("insights_client.metrics._proxy_settings")
-def test_http_client_init_is_not_satellite(proxy_settings, config_file_factory, rhsm_config_file_factory):
+def test_http_client_init_is_satellite(proxy_settings, config_file_factory, rhsm_config_file_factory):
     '''
     Verify that when the configured RHSM hostname does NOT match one of the Red Hat subscription URLs,
     it is determined to be a Satellite-subscribed host

--- a/src/insights_client/tests/test_metrics.py
+++ b/src/insights_client/tests/test_metrics.py
@@ -70,6 +70,7 @@ def test_http_client_init_missing_server_section(proxy_settings, config_file_fac
     assert not metrics_client.cert
     assert metrics_client.base_url == "cloud.redhat.com"
     assert metrics_client.api_prefix == "/api"
+    assert metrics_client.verify is True
 
 @patch("insights_client.metrics._proxy_settings")
 def test_http_client_init_default_cert_auth(proxy_settings, config_file_factory):
@@ -83,6 +84,7 @@ def test_http_client_init_default_cert_auth(proxy_settings, config_file_factory)
         config_file=config_file.name, rhsm_config_file=rhsm_config_file.name,
         cert_file="/path/to/test/cert.pem", key_file="/path/to/test/key.pem")
     assert not metrics_client.auth
+    assert metrics_client.verify is True
     assert metrics_client.cert == ("/path/to/test/cert.pem", "/path/to/test/key.pem")
     assert metrics_client.base_url == "cert.cloud.redhat.com"
     assert metrics_client.api_prefix == "/api"
@@ -99,6 +101,7 @@ def test_http_client_init_is_not_satellite(proxy_settings, config_file_factory, 
         config_file=config_file.name, rhsm_config_file=rhsm_config_file.name,
         cert_file="/path/to/test/cert.pem", key_file="/path/to/test/key.pem")
     assert not metrics_client.auth
+    assert metrics_client.verify is True
     assert metrics_client.cert == ("/path/to/test/cert.pem", "/path/to/test/key.pem")
     assert metrics_client.base_url == "cert.cloud.redhat.com"
     assert metrics_client.api_prefix == "/api"
@@ -111,7 +114,7 @@ def test_http_client_init_is_satellite(proxy_settings, config_file_factory, rhsm
     '''
     config_file = config_file_factory("")
     rhsm_config_file = rhsm_config_file_factory(
-        hostname="satellite.example.com",
+        hostname="satellite.example.com", port="443",
         repo_ca_cert="/path/to/cacert/cert.pem", consumerCertDir="/path/to/sat/certs")
     metrics_client = MetricsHTTPClient(
         config_file=config_file.name, rhsm_config_file=rhsm_config_file.name)

--- a/src/insights_client/tests/test_metrics.py
+++ b/src/insights_client/tests/test_metrics.py
@@ -1,5 +1,5 @@
 
-from configparser import ConfigParser
+from six.moves import configparser
 from tempfile import NamedTemporaryFile
 
 from pytest import fixture
@@ -167,7 +167,7 @@ def test_http_client_init_proxies_rhsm_config(
 
 def test_proxy_settings_no_hostname(rhsm_config_file_factory):
     rhsm_config_file = rhsm_config_file_factory()
-    rhsm_config = ConfigParser()
+    rhsm_config = configparser.ConfigParser()
     rhsm_config.read(rhsm_config_file.name)
     proxy_settings = _proxy_settings(rhsm_config)
     assert proxy_settings is None
@@ -175,7 +175,7 @@ def test_proxy_settings_no_hostname(rhsm_config_file_factory):
 
 def test_proxy_settings_only_hostname(rhsm_config_file_factory):
     rhsm_config_file = rhsm_config_file_factory(proxy_hostname="localhost")
-    rhsm_config = ConfigParser()
+    rhsm_config = configparser.ConfigParser()
     rhsm_config.read(rhsm_config_file.name)
     proxy_settings = _proxy_settings(rhsm_config)
     assert proxy_settings == {"https": "http://localhost:"}
@@ -183,7 +183,7 @@ def test_proxy_settings_only_hostname(rhsm_config_file_factory):
 
 def test_proxy_settings_without_auth(rhsm_config_file_factory):
     rhsm_config_file = rhsm_config_file_factory(proxy_hostname="localhost", proxy_port=3128)
-    rhsm_config = ConfigParser()
+    rhsm_config = configparser.ConfigParser()
     rhsm_config.read(rhsm_config_file.name)
     proxy_settings = _proxy_settings(rhsm_config)
     assert proxy_settings == {"https": "http://localhost:3128"}
@@ -192,7 +192,7 @@ def test_proxy_settings_without_auth(rhsm_config_file_factory):
 def test_proxy_settings_with_empty_auth(rhsm_config_file_factory):
     rhsm_config_file = rhsm_config_file_factory(
         proxy_hostname="localhost", proxy_port=3128, proxy_user="", proxy_password="")
-    rhsm_config = ConfigParser()
+    rhsm_config = configparser.ConfigParser()
     rhsm_config.read(rhsm_config_file.name)
     proxy_settings = _proxy_settings(rhsm_config)
     assert proxy_settings == {"https": "http://localhost:3128"}
@@ -201,7 +201,7 @@ def test_proxy_settings_with_empty_auth(rhsm_config_file_factory):
 def test_proxy_settings_with_whitespace_auth(rhsm_config_file_factory):
     rhsm_config_file = rhsm_config_file_factory(
         proxy_hostname="localhost", proxy_port=3128, proxy_user=" ", proxy_password=" ")
-    rhsm_config = ConfigParser()
+    rhsm_config = configparser.ConfigParser()
     rhsm_config.read(rhsm_config_file.name)
     proxy_settings = _proxy_settings(rhsm_config)
     assert proxy_settings == {"https": "http://localhost:3128"}
@@ -209,7 +209,7 @@ def test_proxy_settings_with_whitespace_auth(rhsm_config_file_factory):
 
 def test_proxy_settings_empty_hostname(rhsm_config_file_factory):
     rhsm_config_file = rhsm_config_file_factory(proxy_hostname="")
-    rhsm_config = ConfigParser()
+    rhsm_config = configparser.ConfigParser()
     rhsm_config.read(rhsm_config_file.name)
     proxy_settings = _proxy_settings(rhsm_config)
     assert proxy_settings is None
@@ -217,7 +217,7 @@ def test_proxy_settings_empty_hostname(rhsm_config_file_factory):
 
 def test_proxy_settings_whitespace_hostname(rhsm_config_file_factory):
     rhsm_config_file = rhsm_config_file_factory(proxy_hostname=" ")
-    rhsm_config = ConfigParser()
+    rhsm_config = configparser.ConfigParser()
     rhsm_config.read(rhsm_config_file.name)
     proxy_settings = _proxy_settings(rhsm_config)
     assert proxy_settings is None
@@ -227,7 +227,7 @@ def test_proxy_settings_with_auth(rhsm_config_file_factory):
     rhsm_config_file = rhsm_config_file_factory(
         proxy_hostname="localhost", proxy_port=3128, proxy_user="user", proxy_password="password"
     )
-    rhsm_config = ConfigParser()
+    rhsm_config = configparser.ConfigParser()
     rhsm_config.read(rhsm_config_file.name)
     proxy_settings = _proxy_settings(rhsm_config)
     assert proxy_settings == {"https": "http://user:password@localhost:3128"}


### PR DESCRIPTION
Also act gracefully when

- the rhsm.conf cannot be read
- rhsm.conf _can_ be read but the cert files do not exist (i.e. system was unregistered but conf is still hanging on the disk)