### PR TITLE
config-fallback

### DIFF
--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -9,10 +9,10 @@ AUTH_METHOD_CERT = "CERT"
 
 
 def _proxy_settings(rhsm_config):
-    hostname = rhsm_config.get("server", "proxy_hostname", fallback=None)
-    port = rhsm_config.get("server", "proxy_port", fallback="")
-    user = rhsm_config.get("server", "proxy_user", fallback="")
-    password = rhsm_config.get("server", "proxy_password", fallback="")
+    hostname = rhsm_config.get("server", "proxy_hostname", fallback="").strip()
+    port = rhsm_config.get("server", "proxy_port", fallback="").strip()
+    user = rhsm_config.get("server", "proxy_user", fallback="").strip()
+    password = rhsm_config.get("server", "proxy_password", fallback="").strip()
 
     if not hostname:
         return None

--- a/src/insights_client/metrics.py
+++ b/src/insights_client/metrics.py
@@ -9,10 +9,10 @@ AUTH_METHOD_CERT = "CERT"
 
 
 def _proxy_settings(rhsm_config):
-    hostname = rhsm_config.get("server", "proxy_hostname").strip()
-    port = rhsm_config.get("server", "proxy_port").strip()
-    user = rhsm_config.get("server", "proxy_user").strip()
-    password = rhsm_config.get("server", "proxy_password").strip()
+    hostname = rhsm_config.get("server", "proxy_hostname", fallback=None)
+    port = rhsm_config.get("server", "proxy_port", fallback="")
+    user = rhsm_config.get("server", "proxy_user", fallback="")
+    password = rhsm_config.get("server", "proxy_password", fallback="")
 
     if not hostname:
         return None

--- a/src/insights_client/tests/test_metrics.py
+++ b/src/insights_client/tests/test_metrics.py
@@ -46,10 +46,10 @@ port = 443
 repo_ca_cert =
 consumerCertDir =
 """ % (
-            "proxy_hostname = %s" % config.get("proxy_hostname") if config.get("proxy_hostname") else "",
-            "proxy_port = %s" % config.get("proxy_port") if config.get("proxy_port") else "",
-            "proxy_user = %s" % config.get("proxy_user") if config.get("proxy_user") else "",
-            "proxy_password = %s" % config.get("proxy_password") if config.get("proxy_password") else "",
+            "proxy_hostname = %s" % config["proxy_hostname"] if "proxy_hostname" in config else "",
+            "proxy_port = %s" % config["proxy_port"] if "proxy_port" in config else "",
+            "proxy_user = %s" % config["proxy_user"] if "proxy_user" in config else "",
+            "proxy_password = %s" % config["proxy_password"] if "proxy_password" in config else "",
         )
         return _tempfile(config)
 

--- a/src/insights_client/tests/test_metrics.py
+++ b/src/insights_client/tests/test_metrics.py
@@ -120,6 +120,14 @@ def test_proxy_settings_without_auth(rhsm_config_file_factory):
     assert proxy_settings == {"https": "http://localhost:3128"}
 
 
+def test_proxy_settings_with_empty_auth(rhsm_config_file_factory):
+    rhsm_config_file = rhsm_config_file_factory(proxy_hostname="localhost", proxy_port=3128, proxy_user="", proxy_password="")
+    rhsm_config = ConfigParser()
+    rhsm_config.read(rhsm_config_file.name)
+    proxy_settings = _proxy_settings(rhsm_config)
+    assert proxy_settings == {"https": "http://localhost:3128"}
+
+
 def test_proxy_settings_with_auth(rhsm_config_file_factory):
     rhsm_config_file = rhsm_config_file_factory(
         proxy_hostname="localhost", proxy_port=3128, proxy_user="user", proxy_password="password"

--- a/src/insights_client/tests/test_metrics.py
+++ b/src/insights_client/tests/test_metrics.py
@@ -37,19 +37,19 @@ def rhsm_config_file_factory():
         config = u"""[server]
 hostname = cert-api.access.redhat.com
 port = 443
-proxy_hostname = %s
-proxy_port = %s
-proxy_user = %s
-proxy_password = %s
+%s
+%s
+%s
+%s
 
 [rhsm]
 repo_ca_cert =
 consumerCertDir =
 """ % (
-            config.get("proxy_hostname", ""),
-            config.get("proxy_port", ""),
-            config.get("proxy_user", ""),
-            config.get("proxy_password", ""),
+            "proxy_hostname = %s" % config.get("proxy_hostname") if config.get("proxy_hostname") else "",
+            "proxy_port = %s" % config.get("proxy_port") if config.get("proxy_port") else "",
+            "proxy_user = %s" % config.get("proxy_user") if config.get("proxy_user") else "",
+            "proxy_password = %s" % config.get("proxy_password") if config.get("proxy_password") else "",
         )
         return _tempfile(config)
 


### PR DESCRIPTION
Fall back to a default value if the key is missing from the ConfigParser. These default values should still enable a properly constructed proxy object, even in the absence of keys or values in the config file.

Fixes: RHBZ#1932153