### PR TITLE
🩹 Make metrics tests distributed

### DIFF
--- a/src/insights_client/tests/Makefile.am
+++ b/src/insights_client/tests/Makefile.am
@@ -1,6 +1,6 @@
 
 nodist_check_SCRIPTS = test_sed.py
-check_SCRIPTS = test_metrics.py \
+dist_check_SCRIPTS = test_metrics.py \
        $(NULL)
 
 if HAVE_PYTEST


### PR DESCRIPTION
_SCRIPTS_ are not distributed by default. We want to distribute tests though. Added _dist__ to the test list, so they are included.

Follow-up to #146.