### PR TITLE
Require egg to be a file only if GPG is enabled

### DIFF
--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -97,7 +97,7 @@ def run_phase(phase, client, validated_eggs):
     all_eggs = [ENV_EGG, NEW_EGG] + validated_eggs
 
     for i, egg in enumerate(all_eggs):
-        if egg is None or not os.path.isfile(egg):
+        if egg is None or (config['gpg'] and not os.path.isfile(egg)):
             if debug:
                 log("Egg does not exist: %s" % egg)
             continue


### PR DESCRIPTION
It is only necessary for an egg to be a file if GPG verification is enabled. Without it, there is no verification and adding a folder instead works just as fine. This makes development and debugging easier.

Better attempt on #136. Should fix problems mentioned in the revert #141.

Can @gravitypriest confirm?