### PR TITLE
feat: add Packit integration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,28 @@
+upstream_package_name: insights-client
+downstream_package_name: insights-client
+specfile_path: out/insights-client.spec
+
+srpm_build_deps:
+  - gawk
+  - rpkg
+
+actions:
+  post-upstream-clone:
+    - mkdir out
+    - rpkg srpm --outdir out
+  get-current-version:
+    - awk '/^Version:/ {print $2;}' out/insights-client.spec
+  create-archive:
+    - bash -c 'echo out/insights-client-*.tar.*'
+  fix-spec-file:
+    - echo 'nothing to fix'
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - centos-stream-8
+      - centos-stream-9
+      - fedora-all
+      - rhel-8
+      - rhel-9


### PR DESCRIPTION
Add a basic configuration for building PRs using Packit, using EL 8/9 and supported Fedora's.

The actions are needed to invoke "rpkg" manually, which is what Copr does.