### PR TITLE
fix: Do not create /root/.gnupg/ directory by accident

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ These instructions require the system to be registered with Red Hat Subscription
    ```shell
    $ sudo mkdir -p /etc/insights-client
    $ sudo touch /etc/insights-client/.exp.sed
+   $ sudo ln -s `pwd`/data/redhattools.pub.gpg /etc/insights-client/
+   $ sudo ln -s `pwd`/data/cert-api.access.redhat.com.pem /etc/insights-client/
    ```
    
    Then you can install the package using pip:


### PR DESCRIPTION
* Card ID: CCT-131
* Card ID: RHEL-2480
* Card ID: RHEL-2482

GPG creates a directory $HOME/.gnupg/ every time it performs some operation. When run under root, but not manually (e.g. via subscription-manager Cockpit plugin), it tries to create and write to this directory, which causes SELinux denials.

This patch utilizes the `--homedir` argument GPG supports in order to move the home directory to a temporary directory for the time of the transaction. After the GPG action is performed, the directory is cleaned up.

This is a companion PR to https://github.com/RedHatInsights/insights-core/pull/3930 and they should be reviewed together.