### PR TITLE
Update man page and README to clarify the --group option

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Command line switches available and their explanations.
 
 - `--register` - Register a system with the Insights API. Required for basic collection & upload, except in the case of certain targets or if `--offline` is specified
 - `--display-name=DISPLAYNAME` - Display name to appear in the insights web UI. This can be used at registration time, or standalone to change the display name any time.
-- `--group=GROUP` - Group to add the system to in the insights web UI. Only used on machine registration.
+- `--group=GROUP` - Add a tag named `group` to the system in the insights web UI and in insights-client tags file.
 - `--retry=RETRIES` - Number of times to retry the collection archive upload. Default is 1.
 - `--quiet` - Run with limited console output. This will only print ERROR level messages.
 - `--silent` - Run with no console output at all.

--- a/docs/insights-client.8
+++ b/docs/insights-client.8
@@ -19,7 +19,7 @@ Unregister host from the Red Hat Insights service.
 .IP "--display-name=DISPLAYNAME"
 Display name to use for this host. May be used during registration.
 .IP "--group=GROUP"
-Group to add this host to. The group will be saved to the tags file.
+Add a tag name group with the specified value to this host. The tag will be saved to the tags file.
 .IP "--retry=RETRIES"
 Number of times to retry uploading. 180 seconds between tries.
 .IP "--validate"


### PR DESCRIPTION
This update is a first step to address #156 it simply updates the man page and the README to clarify what the option currently does.