### PR TITLE
feat: add subpackage for ROS

### DIFF
--- a/data/insights-client.conf
+++ b/data/insights-client.conf
@@ -54,3 +54,5 @@
 
 # Location of the tags file for this system
 #tags_file=/etc/insights-client/tags.yaml
+
+#ros_collect=True

--- a/data/insights-client.conf
+++ b/data/insights-client.conf
@@ -54,5 +54,3 @@
 
 # Location of the tags file for this system
 #tags_file=/etc/insights-client/tags.yaml
-
-#ros_collect=True

--- a/insights-client.spec
+++ b/insights-client.spec
@@ -45,7 +45,7 @@ Sends insightful information to Red Hat for automated analysis
 
 %package ros
 Requires: pcp-zeroconf
-Summary: The subpackage for Resource Optimization Service
+Summary: The subpackage for Insights resource optimization service
 
 %description ros
 
@@ -78,14 +78,16 @@ if [ -d %{_sysconfdir}/motd.d ]; then
 fi
 
 %post ros
-echo
-echo "Removing custom PCP configuration required for Resource Optimization service!"
-echo
 rm -f /var/lib/pcp/config/pmlogger/config.ros
 sed -i "/PCP_LOG_DIR\/pmlogger\/ros/d" /etc/pcp/pmlogger/control.d/local
-echo
-echo "Enabling ros_collect to send PCP archives for Resource Optimization service!"
-sed -i "s/#ros_collect=True/ros_collect=True/" %{_sysconfdir}/insights-client/insights-client.conf
+
+if grep -qv "^ros_collect" %{_sysconfdir}/insights-client/insights-client.conf; then
+cat <<EOF >> %{_sysconfdir}/insights-client/insights-client.conf
+### Begin insights-client-ros ###
+ros_collect=True
+### End insights-client-ros ###
+EOF
+fi
 
 %preun
 %systemd_preun %{name}.timer
@@ -98,9 +100,7 @@ sed -i "s/#ros_collect=True/ros_collect=True/" %{_sysconfdir}/insights-client/in
 %systemd_postun insights-client-boot.service
 
 %postun ros
-echo
-echo "Disabling the ros_collect configuration of Resource Optimization service!"
-sed -i "s/ros_collect=True/#ros_collect=True/" %{_sysconfdir}/insights-client/insights-client.conf
+sed -i '/### Begin insights-client-ros ###/,/### End insights-client-ros ###/d;/ros_collect=True/d' %{_sysconfdir}/insights-client/insights-client.conf
 
 
 # Clean up files created by insights-client that are unowned by the RPM


### PR DESCRIPTION
This add the subpackage ros and config paramter ros_collect to insights-client.conf file to enable the ROS data collection.

Considering there could be two ways to do this and unsure about what can be accepted there is another pr https://github.com/RedHatInsights/insights-client/pull/159