### PR TITLE
build: require subscription-manager

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -30,6 +30,8 @@ Requires: python3-six
 Requires: python3dist(setuptools)
 Requires: coreutils
 
+Requires: subscription-manager
+
 BuildRequires: wget
 BuildRequires: binutils
 BuildRequires: python3-devel


### PR DESCRIPTION
Since the BASIC authentication is deprecated, explicitly require `subscription-manager` so the CERT authentication can be used (since `auto_config` is enabled by default).