### PR TITLE
fix(gpg): Ensure GPG can write into its temporary home directory

### DIFF
--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -26,6 +26,9 @@ RPM_EGG = "/etc/insights-client/rpm.egg"
 MOTD_FILE = "/etc/motd.d/insights-client"
 MOTD_SRC = "/etc/insights-client/insights-client.motd"
 
+TEMPORARY_GPG_HOME_PARENT_DIRECTORY = "/var/lib/insights/"
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -85,7 +88,10 @@ def gpg_validate(path):
     if not os.path.exists(path + ".asc"):
         return False
 
-    home = tempfile.mkdtemp()
+    # The /var/lib/insights/ directory is used instead of /tmp/ because
+    # GPG needs to have RW permissions in it, and existing SELinux rules only
+    # allow access here.
+    home = tempfile.mkdtemp(dir=TEMPORARY_GPG_HOME_PARENT_DIRECTORY)
 
     # Import the public keys into temporary environment
     import_process = subprocess.Popen(


### PR DESCRIPTION
Existing SELinux rules prohibit GPG from accessing arbitrary directories, including those in /tmp/. Both tools can read/write in /var/lib/insights/ because this is where we store the eggs.