### PR TITLE
Fix the grep command of ros postscript

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -90,7 +90,7 @@ fi
 rm -f /var/lib/pcp/config/pmlogger/config.ros
 sed -i "/PCP_LOG_DIR\/pmlogger\/ros/d" /etc/pcp/pmlogger/control.d/local
 
-if grep -qv "^ros_collect" %{_sysconfdir}/insights-client/insights-client.conf; then
+if ! grep -q "^ros_collect" %{_sysconfdir}/insights-client/insights-client.conf; then
 cat <<EOF >> %{_sysconfdir}/insights-client/insights-client.conf
 ### Begin insights-client-ros ###
 ros_collect=True

--- a/insights-client.spec
+++ b/insights-client.spec
@@ -52,6 +52,8 @@ Sends insightful information to Red Hat for automated analysis
 %if %{with ros}
 %package ros
 Requires: pcp-zeroconf
+Requires: insights-client
+
 Summary: The subpackage for Insights resource optimization service
 
 %description ros


### PR DESCRIPTION
I ended up forming the grep cmd out of new file which was just having/not having ros_collect. That resulted in completely different outcome. Below are the details about proposed fix,

The new script example,
~~~
# cat test.sh 
if ! grep -q "^ros_collect" /etc/insights-client/insights-client.conf; then
cat <<EOF >> /etc/insights-client/insights-client.conf
### Begin insights-client-ros ###
ros_collect=True
### End insights-client-ros ###
EOF
fi
~~~

1. When ros_collect already present in file, it does not append config one more time,
~~~
# grep ros_collect /etc/insights-client/insights-client.conf -A 1 -B 1
### Begin insights-client-ros ###
ros_collect=True
### End insights-client-ros ###

# sh test.sh 
# grep ros_collect /etc/insights-client/insights-client.conf -A 1 -B 1
### Begin insights-client-ros ###
ros_collect=True
### End insights-client-ros ###
~~~

2. When ros_collect is not there it adds the config,
~~~
# grep ros_collect /etc/insights-client/insights-client.conf -A 1 -B 1
[no output]
# sh test.sh 
# grep ros_collect /etc/insights-client/insights-client.conf -A 1 -B 1
### Begin insights-client-ros ###
ros_collect=True
### End insights-client-ros ###
~~~

3. Likewise the false param stays False,
~~~
# grep ros_collect /etc/insights-client/insights-client.conf -A 1 -B 1
#tags_file=/etc/insights-client/tags.yaml
ros_collect=False

# sh test.sh 

# grep ros_collect /etc/insights-client/insights-client.conf -A 1 -B 1
#tags_file=/etc/insights-client/tags.yaml
ros_collect=False
~~~