### PR TITLE
build: update the spec file more

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -10,7 +10,7 @@ Version:                {{{ git_dir_version lead=3.2 }}}
 Release:                0%{?dist}
 Source:                 {{{ git_dir_pack }}}
 License:                GPLv2+
-URL:                    http://console.redhat.com/insights
+URL:                    https://console.redhat.com/insights
 Group:                  Applications/System
 Vendor:                 Red Hat, Inc.
 

--- a/insights-client.spec
+++ b/insights-client.spec
@@ -76,6 +76,7 @@ mkdir -p %{buildroot}%{_localstatedir}/cache/insights-client/
 
 %post
 %systemd_post %{name}.timer
+%systemd_post %{name}-boot.service
 if [ -d %{_sysconfdir}/motd.d ]; then
     if [ ! -e %{_sysconfdir}/motd.d/insights-client -a ! -L %{_sysconfdir}/motd.d/insights-client ]; then
         if [ -e %{_localstatedir}/lib/insights/newest.egg ]; then
@@ -103,12 +104,12 @@ fi
 %preun
 %systemd_preun %{name}.timer
 %systemd_preun %{name}.service
-%systemd_preun insights-client-boot.service
+%systemd_preun %{name}-boot.service
 
 %postun
 %systemd_postun %{name}.timer
 %systemd_postun %{name}.service
-%systemd_postun insights-client-boot.service
+%systemd_postun %{name}-boot.service
 
 # Clean up files created by insights-client that are unowned by the RPM
 if [ $1 -eq 0 ]; then

--- a/insights-client.spec
+++ b/insights-client.spec
@@ -14,11 +14,6 @@ URL:                    http://console.redhat.com/insights
 Group:                  Applications/System
 Vendor:                 Red Hat, Inc.
 
-Provides: redhat-access-insights = %{version}-%{release}%{?dist}
-
-Obsoletes: redhat-access-insights <= 1.0.13-2
-Obsoletes: redhat-access-proactive <= 1.0.13-2
-
 BuildArch: noarch
 
 Requires: tar

--- a/insights-client.spec
+++ b/insights-client.spec
@@ -9,7 +9,7 @@ Summary:                Uploads Insights information to Red Hat on a periodic ba
 Version:                {{{ git_dir_version lead=3.2 }}}
 Release:                0%{?dist}
 Source:                 {{{ git_dir_pack }}}
-License:                GPLv2+
+License:                GPL-2.0-or-later
 URL:                    https://console.redhat.com/insights
 Group:                  Applications/System
 Vendor:                 Red Hat, Inc.


### PR DESCRIPTION
Update a bit the spec file used for local builds, so it is closer to what used in RHEL:
- drop very old `redhat-access-insights`/`redhat-access-proactive` references
- use https for an URL
- fix & improve handling of `insights-client-boot.service`

Also, convert the `License` header to SPDX.