### PR TITLE
Various small fixes

### DIFF
--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -8,6 +8,7 @@ import logging
 import os
 import shutil
 import subprocess
+from subprocess import Popen, PIPE
 import sys
 import tempfile
 

--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -12,7 +12,6 @@ from subprocess import Popen, PIPE
 import sys
 import tempfile
 
-import six
 from distutils.version import LooseVersion
 
 
@@ -76,10 +75,7 @@ def egg_version(egg):
     except OSError:
         return None
     stdout, stderr = proc.communicate()
-    if six.PY3:
-        return stdout.decode('utf-8')
-    else:
-        return stdout
+    return stdout.decode('utf-8')
 
 
 def sorted_eggs(eggs):

--- a/src/insights_client/tests/conftest.py
+++ b/src/insights_client/tests/conftest.py
@@ -1,7 +1,6 @@
 import os
 import pathlib
 import sys
-from typing import TYPE_CHECKING
 
 
 def pytest_configure(config):

--- a/src/insights_client/tests/requirements.txt
+++ b/src/insights_client/tests/requirements.txt
@@ -2,5 +2,4 @@ pytest
 # Setuptools is required because we still rely on 'distutils' which have been dropped in Python 3.12.
 # setuptools package ships it vendorized as a top-level package, so for a time being we can rely on it.
 setuptools
-six
 -r requirements-core.txt

--- a/src/insights_client/tests/test_client.py
+++ b/src/insights_client/tests/test_client.py
@@ -24,13 +24,10 @@ def test_keyboard_interrupt(os_uid, client):
 @patch('os.getuid', return_value = 0)
 @patch('insights.client.phase.v1.get_phases')
 @patch('insights.client.InsightsClient')
-@patch('insights_client.sorted_eggs', return_value = "/var/lib/insights/newest.egg")
 @patch('insights_client.subprocess.Popen')
-@patch('insights_client.enumerate', return_value = [("1", "egg")])
-@patch('insights_client.os.path.isfile', return_value = True)
-def test_phase_error_100(isfile, enumerate, mock_subprocess, sorted_eggs, client, p, os_uid):
+def test_phase_error_100(mock_subprocess, client, p, os_uid):
     with pytest.raises(SystemExit) as sys_exit:
         mock_subprocess.return_value.returncode= 100
         mock_subprocess.return_value.communicate.return_value = ('output', 'error')
-        insights_client.run_phase(p, client, sorted_eggs)
+        insights_client.run_phase(p, client, validated_eggs=[])
     assert sys_exit.value.code == 0


### PR DESCRIPTION
- restore needed imports in `__init__.py`
- port away from `six`
- drop unused import in the tests config
- drop useless patches in `test_phase_error_100`

See the messages of each commit for more detailed explanations.