### PR TITLE
build: update pytest executables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,7 +25,7 @@ AC_PATH_PROG([TIMEOUT], [timeout])
 AS_IF([test -z "$TIMEOUT"],[
     AC_MSG_ERROR([timeout is missing from your system...])
 ])
-AC_PATH_PROGS([PYTEST], [pytest pytest-3 pytest3-6])
+AC_PATH_PROGS([PYTEST], [pytest py.test])
 AS_IF([test -z "$PYTEST"],[
     AC_MSG_WARN([failed to find pytest, skipping tests...])
 ])


### PR DESCRIPTION
- add "py.test", which is the old executable in pytest 3
- drop "pytest-3" and "pytest3-6", which refer to a Python 3 version (and this branch is for Python 2)