### PR TITLE
fix: Respect PYTHONPATH environment

### DIFF
--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -193,10 +193,14 @@ def run_phase(phase, client, validated_eggs):
             continue
         client_debug("phase '%s'; egg '%s'" % (phase['name'], egg))
 
-        # set up the env
+        # prepare the environment
+        pythonpath = str(egg)
+        env_pythonpath = os.environ.get("PYTHONPATH", "")  # type: str
+        if env_pythonpath:
+            pythonpath += ":" + env_pythonpath
         insights_env = {
             "INSIGHTS_PHASE": str(phase['name']),
-            "PYTHONPATH": str(egg)
+            "PYTHONPATH": pythonpath,
         }
         env = os.environ
         env.update(insights_env)


### PR DESCRIPTION
If PYTHONPATH is set to non-empty value, include it when running the egg. The Egg path is always the first to ensure the correct egg will be run, but the rest of the paths is now included.

This is useful during development. For example, `rhsm` may only be available on non-standard path (= not as installed package), and without this patch it is not possible to use it.