### PR TITLE
feat: simulate packit setup for non-packit testing

### DIFF
--- a/systemtest/guest-setup.sh
+++ b/systemtest/guest-setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/bash
+# this is a general use version of the guest setup that happens in testing farm
+
+# check for insights-client from existing repos
+if ! dnf info insights-client &>/dev/null; then
+  source <(cat /etc/os-release | grep ^ID)
+  
+  # convert os-release to copr name
+  if [ "$ID" == "centos" ]; then
+    DISTRO='centos-stream'
+  else
+    DISTRO="$ID"
+  fi
+
+  # have to pull from dnf as os-release does not follow the same format on rhel
+  RELEASEVER=$(python3 -c 'import dnf, json; db = dnf.dnf.Base(); print(db.conf.substitutions["releasever"])')
+
+  curl https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/$DISTRO-$RELEASEVER/group_yggdrasil-latest-$DISTRO-$RELEASEVER.repo \
+    -o /etc/yum.repos.d/yggdrasil.repo
+fi
+
+dnf -y install insights-client

--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -2,6 +2,12 @@
 set -eu
 set -x
 
+# get to project root
+cd ../../../
+
+# runs the packit setup
+rpm -q insights-client || ./systemtest/guest-setup.sh
+
 . /etc/os-release
 if test "${ID}" = fedora -a ${VERSION_ID} -ge 39; then
   # HACK
@@ -12,9 +18,6 @@ if test "${ID}" = fedora -a ${VERSION_ID} -ge 39; then
   # - https://github.com/RedHatInsights/insights-client/pull/154
   gpg --import /etc/insights-client/redhattools.pub.gpg
 fi
-
-# get to project root
-cd ../../../
 
 dnf --setopt install_weak_deps=False install -y \
   podman git-core python3-pip python3-pytest


### PR DESCRIPTION
This will aid in downstream testing, eg: beaker, running testing-farm directly, running tmt directly, locally in a container, etc...