### PR TITLE
Apply black and flake8 on src/insights-client.in

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,7 @@
 filename =
     *.py,
     *.py.in,
+    */src/insights-client.in,
 # same limit as black
 max-line-length = 88
 ignore =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [tool.black]
-include = '\.py(\.in)?$'
+include = '(\.py(\.in)?|src/insights-client.in)$'

--- a/src/insights-client.in
+++ b/src/insights-client.in
@@ -4,7 +4,7 @@ import sys
 
 from insights_client import _main
 
-sys.path.insert(1, '@pythondir@')
+sys.path.insert(1, "@pythondir@")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- tweak the configurations of `black` and `flake8` to handle also `src/insights-client.in` (i.e. the main executable of `insight-client`
- reformat `src/insights-client.in` with `black`

Followup of #195 and #196.