### PR TITLE
fix(test): use install_katello_rpm before subman_session

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -21,7 +21,7 @@ def install_katello_rpm(test_config):
 
 @pytest.fixture(scope="session")
 def register_subman(
-    external_candlepin, subman_session, test_config, install_katello_rpm
+    external_candlepin, install_katello_rpm, subman_session, test_config
 ):
     if "satellite" in test_config.environment:
         subman_session.register(


### PR DESCRIPTION
This makes sure that the "install_katello_rpm" fixture is setup before "subman_session", and "install_katello_rpm" is tore down after "subman_session". This should ensure that the katello-ca-consumer RPM is uninstalled after "subman_session" unregisters the system.