### PR TITLE
increasing test timeout to 1h

### DIFF
--- a/systemtest/tests/integration/main.fmf
+++ b/systemtest/tests/integration/main.fmf
@@ -1,3 +1,3 @@
 summary: Runs tmt tests
 test: ./test.sh
-duration: 10m
+duration: 1h


### PR DESCRIPTION
fixes [CCT-438](https://issues.redhat.com/browse/CCT-438) .
This is required due to the fact that all our tests are considered one test under tmt.  These tests are timing out in beaker.