### PR TITLE
fix(test): Unifying the way we assert client is registered/unregistered

### DIFF
--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -1,5 +1,5 @@
 import pytest
-from time import sleep
+import conftest
 
 pytestmark = pytest.mark.usefixtures("register_subman")
 
@@ -11,8 +11,7 @@ def test_set_ansible_host_info(insights_client):
     """
     # Register system against Satellite, and register insights through satellite
     insights_client.register()
-    sleep(10)
-    assert insights_client.is_registered
+    assert conftest.loop_until(lambda: insights_client.is_registered)
 
     # Update ansible-host
     ret = insights_client.run("--ansible-host=foo.example.com", check=False)

--- a/integration-tests/test_registration.py
+++ b/integration-tests/test_registration.py
@@ -2,6 +2,7 @@ import os
 import pytest
 import contextlib
 from pytest_client_tools.util import Version
+import conftest
 
 
 pytestmark = pytest.mark.usefixtures("register_subman")
@@ -11,7 +12,7 @@ MACHINE_ID_FILE: str = "/etc/insights-client/machine-id"
 
 def test_machineid_exists_only_when_registered(insights_client):
     """`machine-id` is only present when insights-client is registered."""
-    assert not insights_client.is_registered
+    assert conftest.loop_until(lambda: not insights_client.is_registered)
     assert not os.path.exists(MACHINE_ID_FILE)
 
     res = insights_client.run(check=False)
@@ -56,7 +57,7 @@ def test_double_registration(insights_client):
 
     This behavior has changed multiple times during the package lifetime.
     """
-    assert not insights_client.is_registered
+    assert conftest.loop_until(lambda: not insights_client.is_registered)
 
     insights_client.register()
     assert os.path.exists(MACHINE_ID_FILE)
@@ -89,7 +90,7 @@ def test_register_group_option(insights_client, legacy_upload_value):
     # make sure the system is not registered to insights
     with contextlib.suppress(Exception):
         insights_client.unregister()
-    assert not insights_client.is_registered
+    assert conftest.loop_until(lambda: not insights_client.is_registered)
     insights_client.config.legacy_upload = legacy_upload_value
     insights_client.config.save()
     register_group_option = insights_client.run(
@@ -102,7 +103,7 @@ def test_register_group_option(insights_client, legacy_upload_value):
 
 def test_registered_and_unregistered_files_are_created_and_deleted(insights_client):
     """'.registered and .unregistered file gets created and deleted"""
-    assert not insights_client.is_registered
+    assert conftest.loop_until(lambda: not insights_client.is_registered)
     assert not os.path.exists("/etc/insights-client/.registered")
 
     insights_client.register()

--- a/integration-tests/test_unregister.py
+++ b/integration-tests/test_unregister.py
@@ -10,22 +10,21 @@ def test_unregister(insights_client):
     If the unregistration is successful, `unregister` method returns True
     """
     insights_client.register()
-    assert insights_client.is_registered
+    assert conftest.loop_until(lambda: insights_client.is_registered)
 
     unregistration_status = insights_client.run("--unregister")
     assert (
         "Successfully unregistered from the Red Hat Insights Service"
         in unregistration_status.stdout
     )
-    assert not insights_client.is_registered
+    assert conftest.loop_until(lambda: not insights_client.is_registered)
 
 
 def test_unregister_twice(insights_client):
     """Test insights-client --unregister on unregistered system
+    If the unregistration is successful, `--unregister` returns True on first attempt
+    and false on subsequent attempts."""
 
-    If the unregistration is successful, `--unregister` returns True on first attempt and
-    false on subsequent attempts.
-    """
     insights_client.register()
     assert conftest.loop_until(lambda: insights_client.is_registered)
 
@@ -39,5 +38,5 @@ def test_unregister_twice(insights_client):
     # unregister twice
     unregistration_status = insights_client.run("--unregister", check=False)
     assert conftest.loop_until(lambda: not insights_client.is_registered)
-    assert unregistration_status.returncode == 0
+    assert unregistration_status.returncode == 1
     assert "This system is already unregistered." in unregistration_status.stdout


### PR DESCRIPTION
Unifying the way we assert client is registered/unregistered + corrected failing assertion