### PR TITLE
chore(test):Adding pkg bzip2 to test setup

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -20,7 +20,7 @@ if test "${ID}" = fedora -a ${VERSION_ID} -ge 39; then
 fi
 
 dnf --setopt install_weak_deps=False install -y \
-  podman git-core python3-pip python3-pytest logrotate
+  podman git-core python3-pip python3-pytest logrotate bzip2
 
 python3 -m venv venv
 # shellcheck disable=SC1091


### PR DESCRIPTION
This change will help failing compressor tests
because of missing bzip2 package.