### PR TITLE
fix(test):added assertions to verify registered state of system

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -37,7 +37,7 @@ def register_subman(
     yield subman_session
 
 
-def loop_until(pred, poll_sec=5, timeout_sec=60):
+def loop_until(pred, poll_sec=5, timeout_sec=90):
     """
     An helper function to handle a time periond waiting for an external service
     to update its state.

--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -125,6 +125,7 @@ def test_client_checkin_offline(insights_client):
     logged, and it exists with a failure code
     """
     insights_client.register()
+    assert conftest.loop_until(lambda: insights_client.is_registered)
     checkin_result = insights_client.run("--offline", "--checkin", check=False)
     assert checkin_result.returncode == 1
     assert "ERROR: Cannot check-in in offline mode." in checkin_result.stderr
@@ -139,6 +140,7 @@ def test_client_diagnosis(insights_client):
     assert "Unable to get diagnosis data: 404" in diagnosis_result.stdout
     # Running diagnosis on registered system
     insights_client.register()
+    assert conftest.loop_until(lambda: insights_client.is_registered)
     with open("/etc/insights-client/machine-id", "r") as f:
         machine_id = f.read()
     diagnosis_result = insights_client.run("--diagnosis")


### PR DESCRIPTION
This change will help mitigate syncup issues with
system state after registration.
Some tests intermitently fail due to slow sync.