### PR TITLE
chore(ci): Add CentOS Stream 10 to pytest matrix

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,6 +15,8 @@ jobs:
             image: "registry.fedoraproject.org/fedora:rawhide"
           - name: "Fedora Latest"
             image: "registry.fedoraproject.org/fedora:latest"
+          - name: "CentOS Stream 10"
+            image: "quay.io/centos/centos:stream10-development"
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
           - name: "CentOS Stream 8"


### PR DESCRIPTION
As of now, `fedora:latest` more or less matches c10s/el10, but they will start to diverge, and in six months they will contain different software. This is proactive measure to start testing on RHEL 10-like system.