### PR TITLE
fix: Allow systemd service to restart itself on failure

### DIFF
--- a/data/systemd/insights-client.service
+++ b/data/systemd/insights-client.service
@@ -13,11 +13,14 @@
 Description=Insights Client
 Documentation=man:insights-client(8)
 After=network.target
+StartLimitIntervalSec=12h
+StartLimitBurst=6
 
 [Service]
-Type=simple
-ExecStart=/usr/bin/insights-client --retry 3
-Restart=no
+Type=exec
+ExecStart=/usr/bin/insights-client
+Restart=on-failure
+RestartSec=1h
 WatchdogSec=900
 CPUQuota=30%
 MemoryHigh=1G


### PR DESCRIPTION
* Card ID: CCT-463

Historically, insights-client has not been able to recover from failures that happened during its automatic execution. When the Core failed for any reason (bad code, network failure, ...), the service would stay in a 'failed' state and would not try to recover.

A few months ago, this has caused a problem that resulted in CCT-370. See https://access.redhat.com/solutions/7056526 for more details.

See the commit description for how to test this change.