### PR TITLE
fix(test): Enhancing test_http_timeout to include CCT-506

### DIFF
--- a/integration-tests/test_connection.py
+++ b/integration-tests/test_connection.py
@@ -56,12 +56,13 @@ def test_http_timeout(insights_client):
         3. The command fails with a return code of 1
         4. The output mentions timeout value
     """
-    insights_client.config.http_timeout = 0.01
+    insights_client.config.http_timeout = 0.1
     insights_client.config.save()
 
     output = insights_client.run("--test-connection", check=False)
     assert output.returncode == 1
-    assert "timeout=0.01" in output.stdout
+    assert "Read timed out. (read timeout=0.1)" in output.stdout
+    assert "Traceback" not in output.stdout
 
 
 def test_noauth_proxy_connection(insights_client, test_config):


### PR DESCRIPTION
Enhancing test_http_timeout to include CCT-506 - insights-client --test-connection not catching ReadTimeoutError Exception

So far this PR is a draft as the CCT card is still in refinement
