### PR TITLE
fix(test): pip fails to install fauxfactory on s390x and ppcle

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -20,7 +20,7 @@ if test "${ID}" = fedora -a ${VERSION_ID} -ge 39; then
 fi
 
 dnf --setopt install_weak_deps=False install -y \
-  podman git-core python3-pip python3-pytest logrotate bzip2
+  podman git-core python3-pip python3-pytest logrotate bzip2 python3-cryptography
 
 python3 -m venv venv
 # shellcheck disable=SC1091


### PR DESCRIPTION
pip fails to install fauxfactory package on s390x and ppcle64 due to dependency on cryptography package. 
Installing python3-cryptography rpm resolves the issue.