### PR TITLE
chore(ci): Use Vault for CentOS Stream 8

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,6 +30,11 @@ jobs:
       - name: "Checkout the repository"
         uses: actions/checkout@v4
 
+      - name: "Use CentOS Vault"
+        if: matrix.name == 'CentOS Stream 8'
+        run: |
+          sed -i 's|#baseurl=http://mirror|baseurl=http://vault|' /etc/yum.repos.d/CentOS-Stream-*.repo
+
       - name: "Install dependencies"
         run: |
           dnf --setopt install_weak_deps=False install -y git-core python3-pip gpg


### PR DESCRIPTION
CentOS Stream 8 reached EOL on 2024-05-31. This patch ensures we can still run EL8-equivalent tests on frozen version of Stream 8.