### PR TITLE
fix(test): Removing use of fauxfactory from integration tests

### DIFF
--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,4 +1,3 @@
 git+https://github.com/ptoscano/pytest-client-tools@main
 pyyaml
 pytest-subtests
-fauxfactory

--- a/integration-tests/test_display_name_option.py
+++ b/integration-tests/test_display_name_option.py
@@ -1,8 +1,10 @@
+import string
+
 import pytest
 import uuid
 import logging
-import fauxfactory
 import json
+import random
 
 from conftest import loop_until
 from constants import HOST_DETAILS
@@ -19,6 +21,10 @@ def read_host_details():
 
 def generate_unique_hostname():
     return f"test-qa.{uuid.uuid4()}.csi-client-tools.example.com"
+
+
+def create_random_string(n: int):
+    return "".join(random.choices(string.ascii_letters, k=n))
 
 
 def test_display_name(insights_client):
@@ -106,7 +112,7 @@ def test_register_twice_with_different_display_name(
         ), "machine-id should remain the same even display-name has been changed"
 
 
-@pytest.mark.parametrize("invalid_display_name", [fauxfactory.gen_alpha(201), ""])
+@pytest.mark.parametrize("invalid_display_name", [create_random_string(201), ""])
 def test_invalid_display_name(invalid_display_name, insights_client):
     """Tries to set an invalid display name.
     invalid display names:

--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -20,7 +20,7 @@ if test "${ID}" = fedora -a ${VERSION_ID} -ge 39; then
 fi
 
 dnf --setopt install_weak_deps=False install -y \
-  podman git-core python3-pip python3-pytest logrotate bzip2 python3-cryptography
+  podman git-core python3-pip python3-pytest logrotate bzip2
 
 python3 -m venv venv
 # shellcheck disable=SC1091


### PR DESCRIPTION
currently tests are failing to install fauxfactory on s390x and ppcle64. It is causing failure in downstream compose testing. Replacing the use of fauxfactory by using python inbuilt 'random' and 'string' modules.
Also reverting python3-cryptography that was added a package to support installation of fauxfactory. Python3-cryptography not required by any other tests