### PR TITLE
Enable redhat-access-insights only in RHEL < 10

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -65,6 +65,7 @@ Resource Optimization service upon modifying ros_collect parameter to True.
 %build
 %{meson} \
     -Dpython=%{__python3} \
+    -Dredhat_access_insights=true \
     %{nil}
 %{meson_build}
 

--- a/insights-client.spec
+++ b/insights-client.spec
@@ -63,7 +63,9 @@ Resource Optimization service upon modifying ros_collect parameter to True.
 
 
 %build
-%{meson} -Dpython=%{__python3}
+%{meson} \
+    -Dpython=%{__python3} \
+    %{nil}
 %{meson_build}
 
 

--- a/insights-client.spec
+++ b/insights-client.spec
@@ -65,7 +65,9 @@ Resource Optimization service upon modifying ros_collect parameter to True.
 %build
 %{meson} \
     -Dpython=%{__python3} \
+%if (0%{?rhel} && 0%{?rhel} < 10)
     -Dredhat_access_insights=true \
+%endif
     %{nil}
 %{meson_build}
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('python', type: 'string', value: 'python3', description: 'python interpreter to use when finding python installation')
 option('auto_registration', type: 'feature', value: 'disabled', description: 'enable automatic registration')
 option('checkin', type: 'feature', value: 'disabled', description: 'enable hourly check-in')
+option('redhat_access_insights', type: 'boolean', value: false, description: 'enable deprecated redhat-access-insights executable')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,7 +1,10 @@
 insights_client_sources = [
   'insights-client.in',
-  'redhat-access-insights.in'
 ]
+
+if get_option('redhat_access_insights')
+  insights_client_sources += 'redhat-access-insights.in'
+endif
 
 foreach source : insights_client_sources
   configure_file(


### PR DESCRIPTION
There is no need for it anymore, so keep it only for existing enterprise
distributions.

A new `redhat_access_insights` meson option (which is false by default) is used to enable that deprecated executable.

Card ID: CCT-419