### PR TITLE
fix(test): Updated logrotate test to verify payload log rotation too

### DIFF
--- a/integration-tests/test_client.py
+++ b/integration-tests/test_client.py
@@ -82,21 +82,50 @@ def test_verify_logrotate_feature(insights_client):
     Ref : https://bugzilla.redhat.com/show_bug.cgi?id=1940267
 
     Test Steps:
-        1-Count the number of log file in beginning
-        2-Rotate logs by running logrotate command on CLI for insights-client
-        3-Verify that log is rotated and new log file is created
+        1 - Perform register and payload operation to ensure both
+            insights-client.log and insights-client-payload.log files have logs
+        2 - Rotate logs by running logrotate command on CLI for insights-client
+        3 - Verify insights-client.log and insights-client-payload.log size is 0B
+        4 - Verify rotated files are created in log dir by comparing number of log files
     """
 
     logrotate_conf_file_path = "/etc/logrotate.d/insights-client"
     logdir = "/var/log/insights-client/"
+    logfile_insights = f"{logdir}/insights-client.log"
+    logfile_payload = f"{logdir}/insights-client-payload.log"
+
     assert os.path.exists(logrotate_conf_file_path), "logrotate is not configured"
-    # It is necessary to perform some command using insights-client
-    # to populate logs
-    insights_client.register()
-    number_of_log_files = len(os.listdir(logdir))
+    """
+     It is necessary to perform some command using insights-client
+     to populate logs.
+     Save the archive, to be used while register operation using --keep-archive.
+     for example-
+     [root@test ~]# insights-client --register --keep-archive
+     Automatic scheduling for Insights has been enabled.
+     Starting to collect Insights data for test
+     Writing RHSM facts to /etc/rhsm/facts/insights-client.facts ...
+     Uploading Insights data.
+     Successfully uploaded report for test.
+     View the Red Hat Insights console at https://console.redhat.com/insights/
+     Copying archive from /var/tmp/insights-client-qxl3vdqy/insights-test-date.tar.gz
+     to /var/cache/insights-client/insights-test-date.tar.gz
+     Insights archive retained in /var/cache/insights-client/insights-test-date.tar.gz
+    """
+    reg_result = insights_client.run("--register", "--keep-archive")
+    assert conftest.loop_until(lambda: insights_client.is_registered)
+
+    archive_name = reg_result.stdout.split()[-1]
+    insights_client.run(
+        f"--payload={archive_name}",
+        "--content-type=gz",
+    )
+    number_of_log_files = len(os.listdir(logdir))  # count of files before rotation
+
     subprocess.check_call(["logrotate", "-vf", logrotate_conf_file_path])
+    assert os.path.getsize(logfile_insights) == 0
+    assert os.path.getsize(logfile_payload) == 0
     number_of_files_after_logrotate = len(os.listdir(logdir))
-    assert number_of_files_after_logrotate == (number_of_log_files + 1)
+    assert number_of_files_after_logrotate == (number_of_log_files + 2)
 
 
 @pytest.mark.usefixtures("register_subman")


### PR DESCRIPTION
Test need to verify logration for insights-client-payload.log files as well.
	The test was failing recently because it was only expecting insights-client.log in the log dir
	which was an incorrect assumption because insights-client-payload.log files are
	written in same log dir when --payload option is used