### PR TITLE
chore: drop references to --force-reregister

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ Command line switches available and their explanations.
 - `--conf`, `-c` - Load a custom configuration file other than the default `/etc/insights-client/insights-client.conf`
 - `--offline` - Run with no network connectivity at all. Implies `--no-upload` and makes machine registration unnecessary.
 - `--logging-file` - Log to a file other than the default `/var/log/insights-client/insights-client.log`
-- `--force-reregister` - Force a new registration. This delete's the machine's existing machine-id and registers a new one.
 - `--verbose` - Run with all log output. This will print DEBUG level messages.
 - `--no-upload` - Collect the archive, but do not upload it.
 - `--keep-archive` - Collect the archive, and do not delete it after upload.

--- a/docs/insights-client.8
+++ b/docs/insights-client.8
@@ -70,8 +70,6 @@ Run a module from within the insights.client package. Analogous to "python -m MO
 Display version.
 .IP "--test-connection"
 Test connectivity to Red Hat.
-.IP "--force-reregister"
-Forcefully reregister this host to Red Hat. Will create a new ID for this host and create a new entry. Use only as directed.
 .IP "--verbose"
 DEBUG output to stdout
 .IP "--no-upload"


### PR DESCRIPTION
`--force-reregister` stopped being useful in insights-core since December 2022, unconditionally erroring out since then when used. Since it is planned to be dropped altogether in insights-core [1], then drop its documentation references.

Related to: CCT-404.

[1] https://github.com/RedHatInsights/insights-core/pull/4162