### PR TITLE
fix: use system temporary directory when running as non-root

### DIFF
--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -32,7 +32,14 @@ MOTD_FILE = "/etc/motd.d/insights-client"
 REGISTERED_FILE = "/etc/insights-client/.registered"
 UNREGISTERED_FILE = "/etc/insights-client/.unregistered"
 
-TEMPORARY_GPG_HOME_PARENT_DIRECTORY = "/var/lib/insights/"
+# If we run as root, use the SELinux-safe temporary directory;
+# otherwise, rely on the default temporary directory.
+# This should be OK as the only operation doable as non-root is
+# --version, and everything else already errors.
+if os.geteuid() == 0:
+    TEMPORARY_GPG_HOME_PARENT_DIRECTORY = "/var/lib/insights/"
+else:
+    TEMPORARY_GPG_HOME_PARENT_DIRECTORY = None
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
The temporary directory chosen to work properly with SELinux is `/var/lib/insights`, which can be accessed only by root.

`insights-client` is basically not usable as non-root, and it will fail with `Insights client must be run as root.`. The only exception here is `insights-client --version`, which is run only in the client without loading the core; the exception is that the client will still verify the available eggs using GPG by default.

Hence, use the default temporary directory when running as non-root: this way the available 
eggs can be validated, and the client will either
- print the version and exit
- keep exiting saying root is required

Followup of commit dd6293d608f61a44e562a1fda44cad82cf667e7d.