### PR TITLE
doc: improve wording on MOTD file handling

### DIFF
--- a/docs/insights-client.8
+++ b/docs/insights-client.8
@@ -84,7 +84,11 @@ Check this host's registration status with Red Hat Insights.
 Log network activity to console.
 
 .SH "MOTD"
-A message will be displayed on login about \fBinsights\-client\fP if installed but has not yet been used at least once. To change or remove this message, edit the \fB/etc/insights-client/insights-client.motd\fP file.
+A message will be displayed on login about \fBinsights\-client\fP if installed but has not yet been used at least once.
+
+To change this message, edit the \fB/etc/insights-client/insights-client.motd\fP file.
+
+To prevent this message to be shown on login, create the \fB/etc/motd.d/insights-client\fP symlink pointing to \fB/dev/null\fP.
 
 .SH "LOGGING"
 \fBinsights\-client\fP utilizes the 'logrotate' tool to rotate log files. To change log rotation options, edit the \fB/etc/logrotate.d/insights-client\fP file. Please refer to the 'logrotate' tool documentation to see all available configuration options.


### PR DESCRIPTION
The wording was not correct, mentioning incorrect instructions on what to do to not make the MOTD show up.

Hence:
- move the instructions on how to change the MOTD text to its own paragraph
- add a new paragraph about disabling the MOTD with the actual symlink needed

Fixes RHEL-50695