### PR TITLE
fix(test): adding a step to verify client registration

### DIFF
--- a/integration-tests/test_motd.py
+++ b/integration-tests/test_motd.py
@@ -1,4 +1,5 @@
 import contextlib
+import conftest
 import os
 import subprocess
 import pytest
@@ -45,6 +46,7 @@ def test_motd(insights_client):
 
     # After registration, the file should not exist.
     insights_client.register()
+    assert conftest.loop_until(lambda: insights_client.is_registered)
     assert not os.path.exists(MOTD_PATH)
 
     # The system was unregistered. Because .unregistered file exists,
@@ -65,6 +67,7 @@ def test_motd_dev_null(insights_client):
         assert os.path.samefile(os.devnull, MOTD_PATH)
 
         insights_client.register()
+        assert conftest.loop_until(lambda: insights_client.is_registered)
         assert os.path.samefile(os.devnull, MOTD_PATH)
 
         insights_client.unregister()

--- a/integration-tests/test_registration.py
+++ b/integration-tests/test_registration.py
@@ -74,6 +74,7 @@ def test_machineid_exists_only_when_registered(insights_client):
     assert not os.path.exists(MACHINE_ID_FILE)
 
     insights_client.register()
+    assert conftest.loop_until(lambda: insights_client.is_registered)
     assert os.path.exists(MACHINE_ID_FILE)
 
     insights_client.unregister()
@@ -158,6 +159,7 @@ def test_registered_and_unregistered_files_are_created_and_deleted(insights_clie
     assert not os.path.exists("/etc/insights-client/.registered")
 
     insights_client.register()
+    assert conftest.loop_until(lambda: insights_client.is_registered)
     assert os.path.exists("/etc/insights-client/.registered")
     assert not os.path.exists("/etc/insights-client/.unregistered")
 


### PR DESCRIPTION
Intermittently some tests fail if there is delay in host getting reflected in inventory after client performs registration, a following unregister command would fail for same reason. So adding a registration verification would help minimize such failures.