### PR TITLE
chore: wrap/split long lines

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,10 +11,6 @@ ignore =
     E203,
     # W503: line break before binary operator
     W503
-per-file-ignores =
-    # some lines are longer than 88
-    src/insights_client/__init__.py: E501
-    integration-tests/test_unregister.py: E501
 extend-exclude =
     # default build directory
     build/,

--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -397,7 +397,8 @@ def update_motd_message():
                 logger.debug("could not remove the MOTD file '%s': %s", MOTD_FILE, exc)
         else:
             logger.debug(
-                ".registered or .unregistered exist; file '%s' correctly does not exist",
+                ".registered or .unregistered exist; file '%s' correctly does "
+                "not exist",
                 MOTD_FILE,
             )
 

--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -450,7 +450,8 @@ def _main():
             try:
                 from insights_client.constants import InsightsConstants
             except ImportError:
-                # The source file is build from 'constants.py.in' and is not available during development
+                # The source file is build from 'constants.py.in' and is not
+                # available during development
                 class InsightsConstants(object):
                     version = "development"
 
@@ -461,8 +462,8 @@ def _main():
         if os.getuid() != 0:
             sys.exit("Insights client must be run as root.")
 
-        # handle client instantiation here so that it isn't done multiple times in __init__
-        # The config can be passed now by parameter
+        # handle client instantiation here so that it isn't done multiple times
+        # in __init__; the config can be passed now by parameter
         client = InsightsClient(config, False)  # read config, but dont setup logging
         logger.debug("InsightsClient initialized. Egg version: %s", client.version())
 


### PR DESCRIPTION
- wrap/split few lines (code & comments) longer than 88
- drop no more needed per-file ignores from flake8 config

No behaviour changes, only formatting.