### PR TITLE
fix(test): Changing the custom fields to enable upload to Polarion

### DIFF
--- a/integration-tests/custom_betelgeuse_config.py
+++ b/integration-tests/custom_betelgeuse_config.py
@@ -2,12 +2,10 @@ from betelgeuse import default_config
 
 TESTCASE_CUSTOM_FIELDS = default_config.TESTCASE_CUSTOM_FIELDS + (
     "casecomponent",
-    "requirement",
     "subsystemteam",
     "reference",
 )
 
 DEFAULT_CASECOMPONENT_VALUE = ""
-DEFAULT_REQUIREMENT_VALUE = ""
 DEFAULT_SUBSYSTEMTEAM_VALUE = ""
 DEFAULT_REFERENCE_VALUE = ""


### PR DESCRIPTION
Requirement is a built-in value in Polarion so while uploading the tests it failed to set up the custom value, therefore I deleted it and the upload to Polarion looks much better, more information in:
[CCT-616](https://issues.redhat.com/browse/CCT-616)