### PR TITLE
fix(test): Improve test_common_specs

### DIFF
--- a/integration-tests/test_common_specs.py
+++ b/integration-tests/test_common_specs.py
@@ -21,7 +21,7 @@ def test_common_specs(insights_client, tmp_path):
         This test verifies that the specified specs can be collected,
         parsed and contain valid data without errors
     :reference:
-    :tags:  Tier 1
+    :tags: Tier 1
     :steps:
         1. Define the list of common specs to be tested
         2. Run the insights-client to collect data and save it in the
@@ -40,12 +40,8 @@ def test_common_specs(insights_client, tmp_path):
     """
     common_specs = [
         "insights.specs.Specs.date.json",
-        "insights.specs.Specs.dmidecode.json",
-        "insights.specs.Specs.fstab.json",
-        "insights.specs.Specs.hostname.json",
         "insights.specs.Specs.hosts.json",
         "insights.specs.Specs.installed_rpms.json",
-        "insights.specs.Specs.ip_addresses.json",
         "insights.specs.Specs.ls_dev.json",
         "insights.specs.Specs.lscpu.json",
         "insights.specs.Specs.lspci.json",
@@ -57,15 +53,30 @@ def test_common_specs(insights_client, tmp_path):
         "insights.specs.Specs.uname.json",
         "insights.specs.Specs.yum_repos_d.json",
     ]
+    # The following specs can't be collected in containers
+    privileged_specs = [
+        "insights.specs.Specs.dmidecode.json",
+        "insights.specs.Specs.fstab.json",
+        "insights.specs.Specs.hostname.json",
+        "insights.specs.Specs.ip_addresses.json",
+    ]
 
     # Running insights-client to collect data in tmp path
     insights_client.run(f"--output-dir={tmp_path}")
 
-    # assert  that spec file exist and content has no error
-    for spec in common_specs:
+    in_container: bool = "container" in os.environ.keys()
+    for spec in common_specs + privileged_specs:
         spec_filepath = tmp_path / "meta_data" / spec
+
+        # assert that spec file exists
         assert os.path.exists(spec_filepath), f"spec file {spec} not found "
+
         with open(spec_filepath, "r") as specfile:
             data = json.load(specfile)
-            assert not data["errors"], f"spec file contains error {data['errors']} "
-            assert data["results"] is not None, "spec file exists but results are none."
+
+        # assert that a spec doesn't contain errors
+        # (unless we are in container and the spec is known to not work in containers)
+        if in_container and spec in privileged_specs:
+            continue
+        assert not data["errors"], f"'{spec}' contains errors: {data['errors']} "
+        assert data["results"] is not None, f"'{spec}' does not contain results"


### PR DESCRIPTION
* Card ID: CCT-934

Specs that run 'hostname' or try to access special system files (e.g. /etc/fstab) fail in containers. This patch ensures spec contents are not asserted if there's no way they were collected.