### PR TITLE
fix(test): Force non-legacy with auto_config=False

### DIFF
--- a/integration-tests/test_display_name_option.py
+++ b/integration-tests/test_display_name_option.py
@@ -230,6 +230,7 @@ def test_display_name_disable_autoconfig_and_autoupdate(insights_client, test_co
         3. Host appears in inventory with the display name matching the one that was set
     """
     # configuration on insights-client.conf
+    insights_client.config.legacy_upload = False
     insights_client.config.cert_verify = True
     insights_client.config.auto_update = False
     insights_client.config.auto_config = False


### PR DESCRIPTION
* Card ID: CCT-934

insights-client usually upgrades to use non-legacy API. But with `auto_config=False`, this code isn't run and the upload to Ingress fails. We have to set this explicitly if we want to test in non-production environments.