### PR TITLE
fix(test): Skip hostname redaction in containers

### DIFF
--- a/integration-tests/test_redaction.py
+++ b/integration-tests/test_redaction.py
@@ -125,6 +125,10 @@ def test_redaction_on_file(insights_client, tmp_path, removed_file):
         os.remove(FILE_REDACTION_FILE)
 
 
+@pytest.mark.skipif(
+    "container" in os.environ.keys(),
+    reason="Containers cannot change hostnames",
+)
 def test_redaction_on_pattern_hostname(insights_client, tmp_path):
     """
     :id: 641edf11-ace1-4a98-9fb4-198cf9e5e4d0


### PR DESCRIPTION
* Card ID: CCT-934

Containers are not in control of their own hostnames, they are usually set from the host system. Because this test runs 'hostnamectl set-hostname', it has to be skipped when we're not running on a bare metal/VM system.