### PR TITLE
Feat/cct-144 lines # core_collect=True ...

### DIFF
--- a/data/insights-client.conf
+++ b/data/insights-client.conf
@@ -43,9 +43,6 @@
 # Timeout for HTTP calls, in seconds
 #http_timeout=120
 
-# Use insights-core as the collection source. Included for compatibility only. Modify only as directed.
-#core_collect=True
-
 # Location of the redaction file for commands, files, and components
 #redaction_file=/etc/insights-client/file-redaction.yaml
 


### PR DESCRIPTION
Lines # core_collect and its description above it
were removed from `insights-client.conf`.

CARD CCT-144