### PR TITLE
fix(test): Make file redaction work without filters.yaml configured

### DIFF
--- a/integration-tests/test_redaction.py
+++ b/integration-tests/test_redaction.py
@@ -16,7 +16,7 @@ from enum import Enum
 
 pytestmark = pytest.mark.usefixtures("register_subman")
 TEST_CMD = ["/usr/bin/uptime", "/sbin/lsmod", "/bin/ls", "/sbin/ethtool"]
-TEST_FILE = ["/proc/cpuinfo", "/proc/meminfo", "/etc/yum.conf", "/etc/os-release"]
+TEST_FILE = ["/proc/cpuinfo", "/proc/meminfo", "/etc/os-release"]
 FILE_REDACTION_FILE = "/etc/insights-client/file-redaction.yaml"
 CONTENT_REDACTION_FILE = "/etc/insights-client/file-content-redaction.yaml"
 


### PR DESCRIPTION
File filtering is an inverse of redaction: only lines that have their prefix in an allowlist are collected. Because a custom-built egg does not have those, we cannot test for '/etc/yum.conf'.