### PR TITLE
fix(test): Use custom version and release for Core

### DIFF
--- a/systemtest/insights-core-setup.sh
+++ b/systemtest/insights-core-setup.sh
@@ -60,6 +60,10 @@ git clone https://github.com/RedHatInsights/insights-core.git
 cd insights-core
 git switch $insightsCoreBranch
 
+# Overwrite version and release of Core, to ensure we're always newer than released versions
+sed -i "s/3.0.8/9.99.999/" insights/VERSION
+sed -i "s/dev/0/" insights/RELEASE
+
 ./build_client_egg.sh
 cp insights.zip last_stable.egg
 gpg --detach-sign -u $KEYID --armor last_stable.egg


### PR DESCRIPTION
* Card ID: CCT-685

This patch addresses two different problems in how we test the Core.

First, it sets the version to something very high that will never be achieved in a reasonable time. This ensures that integration tests which require version check to account for different behavior work correctly even with an egg that hasn't been built and released yet.

Second, it sets the release to '0' instead of a string. This has been breaking the version detection, since the value is usually an integer.