### PR TITLE
spec: remove unused python3-magic dependency

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -24,7 +24,6 @@ Requires: pciutils
 %{?systemd_requires}
 Requires: python3-requests >= 2.6
 Requires: python3-PyYAML
-Requires: python3-magic
 Requires: python3-six
 Requires: python3dist(setuptools)
 Requires: coreutils


### PR DESCRIPTION
The python file/libmagic bindings are now named python3-file-magic, while python3-magic is now provided by a separate package of a PyPI module.  In any case, it does not appear that either is used in insights-clients.

Related: https://bugzilla.redhat.com/show_bug.cgi?id=2020606