### PR TITLE
docs: Undocument --conf and --logging-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,9 +154,7 @@ Command line switches available and their explanations.
 - `--retry=RETRIES` - Number of times to retry the collection archive upload. Default is 1.
 - `--quiet` - Run with limited console output. This will only print ERROR level messages.
 - `--silent` - Run with no console output at all.
-- `--conf`, `-c` - Load a custom configuration file other than the default `/etc/insights-client/insights-client.conf`
 - `--offline` - Run with no network connectivity at all. Implies `--no-upload` and makes machine registration unnecessary.
-- `--logging-file` - Log to a file other than the default `/var/log/insights-client/insights-client.log`
 - `--verbose` - Run with all log output. This will print DEBUG level messages.
 - `--no-upload` - Collect the archive, but do not upload it.
 - `--keep-archive` - Collect the archive, and do not delete it after upload.

--- a/docs/insights-client.8
+++ b/docs/insights-client.8
@@ -32,14 +32,10 @@ Display no messages to stdout.
 Enable automatic scheduling.
 .IP "--disable-schedule"
 Disable automatic scheduling.
-.IP "-c CONF, --conf=CONF"
-Pass a custom config file.
 .IP "--compressor"
 Specifies the compression algorithm to use. Choices are gz, bz2, xz, and none. Defaults to gz.
 .IP "--offline"
 Collect locally only, do not connect to Insights and do not upload.
-.IP "--logging-file"
-Specify a logfile other than the default.
 .IP "--payload=FILE"
 Skip collection and upload a specified archive. Requires --content-type.
 .IP "--content-type=TYPE"

--- a/integration-tests/test_manpage.py
+++ b/integration-tests/test_manpage.py
@@ -15,7 +15,6 @@ import pytest
     [
         "--checkin",
         "--compliance",
-        "--conf",
         "--content-type",
         "--diagnosis",
         "--disable-schedule",
@@ -24,7 +23,6 @@ import pytest
         "--group",
         "--keep-archive",
         "--list-specs",
-        "--logging-file",
         "--net-debug",
         "--no-upload",
         "--offline",


### PR DESCRIPTION
* Card ID: CCT-732

The CLI includes many flags that could be reimplemented, but `conf` and `logging-file` are harder to support and offer little value to customers. Instead of removing them from the CLI, we'll remove them from the man page and document the change in the RHEL release notes, as Core is shipped to RHEL 6+ and cannot immediately remove these flags.