### PR TITLE
[el8] test(ci): Drop CentOS Stream 10 and Fedora containers

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "src/**"
+      - ".github/workflows/pytest.yml"
 
 jobs:
   pytest:
@@ -11,12 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Fedora Rawhide"
-            image: "registry.fedoraproject.org/fedora:rawhide"
-          - name: "Fedora Latest"
-            image: "registry.fedoraproject.org/fedora:latest"
-          - name: "CentOS Stream 10"
-            image: "quay.io/centos/centos:stream10-development"
           - name: "CentOS Stream 9"
             image: "quay.io/centos/centos:stream9"
           - name: "CentOS Stream 8"


### PR DESCRIPTION
This branch now only targets 'el8' and 'el9', it is not necessary to run on newer systems, as they start to diverge.