### PR TITLE
docs: Remove reference to BASIC authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,10 +128,6 @@ Configuration variables available in the configuration file and their explanatio
 
 - `loglevel` - set the Python logger's default level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Default `DEBUG`
 - `auto_config` - attempt to auto-configure the network connection with Satellite or RHSM. Default `True`
-- `authmethod` - authentication method for the Portal (BASIC, CERT). Default is `BASIC`
-Note: when `auto_config` is enabled, `CERT` will be used if RHSM or Satellite is detected
-- `username` - username for basic auth. Blank by default
-- `password` - password for basic auth. Blank by default
 - `base_url` - base url for the Insights API. Default `cert-api.access.redhat.com:443/r/insights`
 - `cert_verify` - path to CA cert to verify SSL against. Default `/etc/insights-client/cert-api.access.redhat.com.pem`
 - `proxy` - proxy URL. Blank by default
@@ -194,74 +190,22 @@ These switches are undocumented and for developer use only.
 ## Recommended Developer Config
 For convenience, some sample configs are provided here for developers for connecting to the different environments the client can interface with. These configurations can be defined via config file or via environment variables using the naming described under **Environment Variables**. The following are in config file notation and can be used as drop-in configuration.
 
-### CI (Basic Auth)
-**Note:** CI requires basic auth.
-```
-[insights-client]
-auto_config=False
-username=<username>
-password=<password>
-legacy_upload=False
-base_url=ci.cloud.redhat.com/api
-cert_verify=False
-```
-### QA (Basic Auth)
-**Note:** QA requires basic auth.
-```
-[insights-client]
-auto_config=False
-username=<username>
-password=<password>
-legacy_upload=False
-base_url=qa.cloud.redhat.com/api
-cert_verify=False
-```
 ### Stage (RHSM Auth)
 **Note:** This configuration assumes that the system is registered to Stage RHSM. Insights Client will autoconfigure to interface with stage.
 ```
 [insights-client]
 proxy=http://squid.corp.redhat.com:3128
 ```
-### Stage (Basic Auth)
-```
-[insights-client]
-auto_config=False
-username=<username>
-password=<password>
-legacy_upload=False
-base_url=cert.cloud.stage.redhat.com/api
-cert_verify=True
-proxy=http://squid.corp.redhat.com:3128
-```
 ### Prod (RHSM Auth)
 ```
 [insights-client]
 auto_config=False
-authmethod=CERT
-legacy_upload=False
-base_url=cert.cloud.redhat.com/api
-cert_verify=True
-```
-### Prod (Basic Auth)
-```
-[insights-client]
-auto_config=False
-username=<username>
-password=<password>
 legacy_upload=False
 base_url=cert.cloud.redhat.com/api
 cert_verify=True
 ```
 ### Prod [classic API] (RHSM Auth)
 No additional configuration is required beyond the defaults. Insights Client will autoconfigure to interface with classic prod.
-
-### Prod [classic API] (Basic Auth)
-```
-[insights-client]
-auto_config=False
-username=<username>
-password=<password>
-```
 
 
 ## Collection

--- a/data/insights-client.conf
+++ b/data/insights-client.conf
@@ -7,15 +7,6 @@
 # Attempt to auto configure with Satellite server
 #auto_config=True
 
-# Change authentication method, valid options BASIC, CERT. Default BASIC
-#authmethod=BASIC
-
-# username to use when authmethod is BASIC
-#username=
-
-# password to use when authmethod is BASIC
-#password=
-
 # Base URL for the Insights API
 #base_url=cert-api.access.redhat.com:443/r/insights
 

--- a/docs/insights-client.conf.5
+++ b/docs/insights-client.conf.5
@@ -11,12 +11,6 @@ The \fBinsights\-client.conf\fP file contains configuration information for \fBi
 Change log level, valid options DEBUG, INFO, WARNING, ERROR, CRITICAL.
 .IP "auto_config=True"
 Automatically attempt to configure connectivity to Red Hat Insights. If an RHSM or Satellite subscription is detected, CERT auth will be automatically selected.
-.IP "authmethod=BASIC"
-Change authentication method, valid options BASIC, CERT. Default BASIC.\&
-.IP "username="
-Username to use when authmethod is BASIC.
-.IP "password="
-Password to use when authmethod is BASIC.
 .IP "base_url=cert-api.access.redhat.com:443/r/insights"
 Base URL for API Interactions.
 .IP "proxy=http://user:pass@192.168.100.50:8080"


### PR DESCRIPTION
* Card ID: CCT-238

Since BASIC authentication has reached its EOL in insights services, it is no longer relevant or supported in the client tool. This update removes all references to BASIC authentication from the client configuration and documentation.