### PR TITLE
[el8] ci: drop el9/10 & fedora jobs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,8 +12,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "CentOS Stream 9"
-            image: "quay.io/centos/centos:stream9"
           - name: "CentOS Stream 8"
             image: "quay.io/centos/centos:stream8"
 
@@ -26,7 +24,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: "Use CentOS Vault"
-        if: matrix.name == 'CentOS Stream 8'
         run: |
           sed -i 's|#baseurl=http://mirror|baseurl=http://vault|' /etc/yum.repos.d/CentOS-Stream-*.repo
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,11 +22,7 @@ jobs:
     trigger: pull_request
     targets:
       - centos-stream-8
-      - centos-stream-9
-      - centos-stream-10
-      - fedora-all
       - rhel-8
-      - rhel-9
 
   - job: copr_build
     trigger: commit
@@ -35,19 +31,13 @@ jobs:
     project: latest
     targets:
       - centos-stream-8
-      - centos-stream-9
-      - centos-stream-10
-      - fedora-all
       - rhel-8
-      - rhel-9
 
   - job: tests
     trigger: pull_request
     identifier: "unit/centos-stream"
     targets:
       - centos-stream-8
-      - centos-stream-9
-      - centos-stream-10
     labels:
       - unit
     tf_extra_params:
@@ -58,27 +48,11 @@ jobs:
 
   - job: tests
     trigger: pull_request
-    identifier: "unit/fedora"
-    targets:
-      - fedora-all
-    labels:
-      - unit
-    tf_extra_params:
-      environments:
-        - artifacts:
-            - type: repository-file
-              id: https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/fedora-$releasever/group_yggdrasil-latest-fedora-$releasever.repo
-
-  - job: tests
-    trigger: pull_request
     identifier: "unit/rhel"
     targets:
       rhel-8-x86_64:
         distros:
           - RHEL-8-Released
-      rhel-9-x86_64:
-        distros:
-          - RHEL-9.4.0-Nightly
     labels:
       - unit
     tf_extra_params:


### PR DESCRIPTION
The `el8` branch targets only EL8, so drop EL 9, EL 10, and Fedora distros from the GitHub actions and the packit config.

Card ID: CCT-1075