### PR TITLE
fix: Disable legacy API by default in RHEL 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Configuration variables available in the configuration file and their explanatio
 
 - `loglevel` - set the Python logger's default level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). Default `DEBUG`
 - `auto_config` - attempt to auto-configure the network connection with Satellite or RHSM. Default `True`
-- `base_url` - base url for the Insights API. Default `cert-api.access.redhat.com:443/r/insights`
+- `base_url` - base url for the Insights API. Default `cert.cloud.redhat.com:443/api`
 - `cert_verify` - path to CA cert to verify SSL against. Default `/etc/insights-client/cert-api.access.redhat.com.pem`
 - `proxy` - proxy URL. Blank by default
 - `auto_update` - whether to update the rule spec file (uploader.json) and the insights-core egg. Default `True`
@@ -139,7 +139,7 @@ Configuration variables available in the configuration file and their explanatio
 - `core_collect` - if `True`, use insights-core to run collection instead of commands/files from uploader.json. Default `False`
 - `redaction_file` - location of the redaction file. Default `/etc/insights-client/file-redaction.yaml`
 - `content_redaction_file` - location of the content redaction file. Default `/etc/insights-client/file-content-redaction.yaml`
-- `legacy_upload` - Use legacy HTTP configuration to perform the upload. Default `True`
+- `legacy_upload` - Use legacy HTTP configuration to perform the upload. Default `False`
 
 ### Command Line Switches
 Command line switches available and their explanations.

--- a/data/insights-client.conf
+++ b/data/insights-client.conf
@@ -8,7 +8,7 @@
 #auto_config=True
 
 # Base URL for the Insights API
-#base_url=cert-api.access.redhat.com:443/r/insights
+#base_url=cert.cloud.redhat.com:443/api
 
 # URL for your proxy.  Example: http://user:pass@192.168.100.50:8080
 #proxy=
@@ -42,3 +42,7 @@
 
 # Location of the tags file for this system
 #tags_file=/etc/insights-client/tags.yaml
+
+# Use legacy API URLs
+# Warning: Legacy API is not supported in this RHEL version and may result in broken functionality.
+legacy_upload=False

--- a/docs/insights-client.conf.5
+++ b/docs/insights-client.conf.5
@@ -11,7 +11,7 @@ The \fBinsights\-client.conf\fP file contains configuration information for \fBi
 Change log level, valid options DEBUG, INFO, WARNING, ERROR, CRITICAL.
 .IP "auto_config=True"
 Automatically attempt to configure connectivity to Red Hat Insights. If an RHSM or Satellite subscription is detected, CERT auth will be automatically selected.
-.IP "base_url=cert-api.access.redhat.com:443/r/insights"
+.IP "base_url=cert.cloud.redhat.com:443/api"
 Base URL for API Interactions.
 .IP "proxy=http://user:pass@192.168.100.50:8080"
 URL for the proxy.


### PR DESCRIPTION
* Card ID: RHEL-67937
* Card ID: CCT-1003

Ensure that client uses the non-legacy API URI `cert.cloud.redhat.com` by default. Previously, some commands temporarily switched to the non-legacy API URI, but this behavior was not consistent across all commands.

---

This pull request should be also backported to following maintenance branches:

- [ ] `el8` (RHEL 8, RHEL 9)
- [ ] `el7` (RHEL 7)