### PR TITLE
[el9] fix(test): Correct five failing integration tests

### DIFF
--- a/integration-tests/test_checkin.py
+++ b/integration-tests/test_checkin.py
@@ -9,6 +9,8 @@
 import contextlib
 import json
 import pytest
+from pytest_client_tools.util import Version
+
 from constants import HOST_DETAILS
 import conftest
 
@@ -85,7 +87,12 @@ def test_client_checkin_unregistered(insights_client):
     assert conftest.loop_until(lambda: not insights_client.is_registered)
 
     checkin_result = insights_client.run("--checkin", check=False)
-    assert checkin_result.returncode == 1
-    assert (
-        "Error: failed to find host with matching machine-id" in checkin_result.stdout
-    )
+    if insights_client.core_version >= Version(3, 4, 25):
+        assert checkin_result.returncode > 0
+        assert "This host is not registered" in checkin_result.stdout
+    else:
+        assert checkin_result.returncode == 1
+        assert (
+            "Error: failed to find host with matching machine-id"
+            in checkin_result.stdout
+        )

--- a/integration-tests/test_collection.py
+++ b/integration-tests/test_collection.py
@@ -298,10 +298,9 @@ def test_branch_info(insights_client, test_config, subman, tmp_path):
         1. The branch_info file is generated
         2. The branch_info includes correct values
     """
-    insights_client.run("--output-dir", tmp_path.name)
-
-    branch_info_path: str = os.path.join(tmp_path.name, "branch_info")
-    with open(branch_info_path, "r") as file:
+    insights_client.run("--output-dir", tmp_path.absolute())
+    branch_info_path = tmp_path / "branch_info"
+    with branch_info_path.open("r") as file:
         data = json.load(file)
 
     if "satellite" in test_config.environment:
@@ -352,13 +351,11 @@ def test_archive_structure(insights_client, tmp_path):
         "usr",
     ]
 
-    insights_client.run("--output-dir", tmp_path.name)
-
-    extracted_dirs_files = os.listdir(tmp_path.name)  # type: list[str]
+    insights_client.run("--output-dir", tmp_path.absolute())
+    extracted_dirs_files = os.listdir(tmp_path)  # type: list[str]
     missing_dirs = [f for f in archive_content if f not in extracted_dirs_files]
     assert not missing_dirs, f"Missing directories {missing_dirs}"
 
-    data_dir_path = os.path.join(tmp_path.name, "data")
-    data_subdirs = os.listdir(data_dir_path)  # type: list[str]
+    data_subdirs = os.listdir(tmp_path / "data")  # type: list[str]
     missing_subdirs = [f for f in archive_data_content if f not in data_subdirs]
     assert not missing_subdirs, f"Missing subdirectory {missing_subdirs}"

--- a/integration-tests/test_file_workflow.py
+++ b/integration-tests/test_file_workflow.py
@@ -66,10 +66,14 @@ def test_file_workflow_with_an_archive_with_only_one_canonical_fact(
     insights_client.run("--check-results")  # to get host details from inventory
     with open(HOST_DETAILS, "r") as data_file:
         file_content = json.load(data_file)
-        host_data = file_content["results"][0]
 
-    assert host_data["insights_id"] == machine_id
-    assert host_data["fqdn"] is None
+    assert "count" in file_content.keys()
+    assert file_content["count"] == 1
+    assert "results" in file_content.keys()
+    host_data = file_content["results"][0]
+
+    assert host_data.get("insights_id") == machine_id
+    assert host_data.get("fqdn", None) is None
 
 
 def test_file_workflow_with_an_archive_without_canonical_facts(

--- a/integration-tests/test_file_workflow.py
+++ b/integration-tests/test_file_workflow.py
@@ -7,6 +7,7 @@
 """
 
 import json
+import os
 import random
 import string
 import subprocess
@@ -122,6 +123,10 @@ def test_file_workflow_with_an_archive_without_canonical_facts(
     assert "Error: failed to find host with matching machine-id" in check_results.stdout
 
 
+@pytest.mark.skipif(
+    "container" in os.environ.keys(),
+    reason="Containers cannot change hostnames",
+)
 def test_file_workflow_archive_update_host_info(insights_client, external_inventory):
     """
     :id: 336abff9-4263-4f1d-9448-2cd05d40a371


### PR DESCRIPTION
This PR fixes several tests that were failing. Some only in containers, some also for CI jobs in Jenkins.

---

This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/324