### PR TITLE
chore: Release insights-client-v3.10.1

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('insights-client',
-  version: '3.10.0',
+  version: '3.10.1',
   meson_version: '>=0.49'
 )
 


### PR DESCRIPTION
Since the build issues were fixed in previous commit, we can create a new tag that will actually build.
