### PR TITLE
test: Status code indicates registration status

### DIFF
--- a/integration-tests/test_motd.py
+++ b/integration-tests/test_motd.py
@@ -69,7 +69,7 @@ def test_motd(insights_client):
         5. The MOTD file is still not present
     """
     # If the system is not registered, the file should be present.
-    insights_client.run("--status")
+    insights_client.run("--status", check=False)
     assert os.path.exists(MOTD_PATH)
 
     # After registration, the file should not exist.
@@ -109,7 +109,7 @@ def test_motd_dev_null(insights_client):
         os.symlink(os.devnull, MOTD_PATH)
         stack.callback(os.unlink, MOTD_PATH)
 
-        insights_client.run("--status")
+        insights_client.run("--status", check=False)
         assert os.path.samefile(os.devnull, MOTD_PATH)
 
         insights_client.register()


### PR DESCRIPTION
* Card ID: CCT-1059

Status code returned by `insights-client --status` indicates whether a host is registered or not. This change updates the failing integration tests.

This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)

Since [insights-core#4344](https://github.com/RedHatInsights/insights-core/pull/4344) was merged, this PR is now ready for review.