### PR TITLE
[el8] test: Status code indicates registration status

### DIFF
--- a/integration-tests/test_motd.py
+++ b/integration-tests/test_motd.py
@@ -70,7 +70,7 @@ def test_motd(insights_client):
         5. The MOTD file is still not present
     """
     # If the system is not registered, the file should be present.
-    insights_client.run("--status")
+    insights_client.run("--status", check=False)
     assert os.path.exists(MOTD_PATH)
 
     # After registration, the file should not exist.
@@ -111,7 +111,7 @@ def test_motd_dev_null(insights_client):
         os.symlink(os.devnull, MOTD_PATH)
         stack.callback(os.unlink, MOTD_PATH)
 
-        insights_client.run("--status")
+        insights_client.run("--status", check=False)
         assert os.path.samefile(os.devnull, MOTD_PATH)
 
         insights_client.register()

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -8,6 +8,7 @@
 
 import contextlib
 import pytest
+from pytest_client_tools.util import Version
 from time import sleep
 import conftest
 
@@ -60,9 +61,11 @@ def test_status_unregistered(external_candlepin, insights_client):
         2. Run `insights-client --status` command
     :expectedresults:
         1. The client unregisters successfully
-        2. If 'legacy_upload' is True return code is 1 and output contains
+        2. If 'legacy_upload' is True, return code is 1 and output contains
             "Insights API says this machine is NOT registered."
-            If 'legacy_upload' is False return code is 0 and output contains
+            If 'legacy_upload' is False, on systems with version 3.5.3 and
+            higher, return code is 1 and output contains "This host is
+            unregistered.". Otherwise return code is 0 and output contains
             "This host is unregistered.\n"
     """
     # running unregistration to ensure system is unregistered
@@ -78,5 +81,8 @@ def test_status_unregistered(external_candlepin, insights_client):
             in registration_status.stdout
         )
     else:
-        assert registration_status.returncode == 0
+        if insights_client.core_version >= Version(3, 5, 3):
+            assert registration_status.returncode == 1
+        else:
+            assert registration_status.returncode == 0
         assert "This host is unregistered.\n" == registration_status.stdout


### PR DESCRIPTION
* Card ID: CCT-1059

Status code returned by `insights-client --status` indicates whether a host is registered or not. This change updates the failing integration tests.

---

This pull request is a backport of: #337 
