### PR TITLE
test: Check for bootc/image-mode deployments

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -5,16 +5,19 @@ set -x
 # get to project root
 cd ../../../
 
-# Check for GitHub pull request ID and install build if needed.
-# This is for the downstream PR jobs.
-[ -z "${ghprbPullId+x}" ] || ./systemtest/copr-setup.sh
+# Check for bootc/image-mode deployments which should not run dnf
+if ! command -v bootc >/dev/null || bootc status | grep -q 'type: null'; then
+  # Check for GitHub pull request ID and install build if needed.
+  # This is for the downstream PR jobs.
+  [ -z "${ghprbPullId+x}" ] || ./systemtest/copr-setup.sh
 
-# Simulate the packit setup on downstream builds.
-# This is for ad-hoc and compose testing.
-rpm -q insights-client || ./systemtest/guest-setup.sh
+  # Simulate the packit setup on downstream builds.
+  # This is for ad-hoc and compose testing.
+  rpm -q insights-client || ./systemtest/guest-setup.sh
 
-dnf --setopt install_weak_deps=False install -y \
-  podman git-core python3-pip python3-pytest logrotate bzip2 zip
+  dnf --setopt install_weak_deps=False install -y \
+    podman git-core python3-pip python3-pytest logrotate bzip2 zip
+fi
 
 # If this is an insightsCore PR build and sign the new egg.
 [ -z "${insightsCoreBranch+x}" ] || ./systemtest/insights-core-setup.sh


### PR DESCRIPTION
DNF commands without special options do not work in image-mode, and we will have pre-prepared images with needed packaging - so we will skip executing these bits for bootc images.

Card: CCT-1183