### PR TITLE
fix: display insights-client version when no egg is found

### DIFF
--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -431,7 +431,9 @@ def _main():
         valid_env_egg = []
 
     if not validated_eggs and not valid_env_egg:
-        sys.exit("No GPG-verified initial eggs can be found")
+        print("Client: %s" % InsightsConstants.version)
+        print("Core: not found")
+        return
 
     # ENV egg comes first
     all_valid_eggs = valid_env_egg + validated_eggs


### PR DESCRIPTION
Add print of insights-client version to 'if' block checking presence of valid eggs.

As whole try-except block is repeated from later code, this solution is a bit provisory.

Card ID: CCT-393

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->

<!--
This pull request is a backport of: URL
-->

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->
