### PR TITLE
chore(test): Increase pytest logging verbosity

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -25,7 +25,7 @@ python3 -m venv venv
 
 pip install -r integration-tests/requirements.txt
 
-pytest --junit-xml=./junit.xml -v integration-tests
+pytest --log-level debug --junit-xml=./junit.xml -v integration-tests
 retval=$?
 
 if [ -d "$TMT_PLAN_DATA" ]; then


### PR DESCRIPTION
Some tests may fail on setup phase, when e.g. subscription-manager fails to register. Setting log level to debug will allow us to see logs from pytest-client-tools, and better investigate the cause for the failure.

---

This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
