### PR TITLE
[el8] chore(test): Increase pytest logging verbosity

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -25,7 +25,7 @@ python3 -m venv venv
 
 pip install -r integration-tests/requirements.txt
 
-pytest --junit-xml=./junit.xml -v integration-tests
+pytest --log-level debug --junit-xml=./junit.xml -v integration-tests
 retval=$?
 
 if [ -d "$TMT_PLAN_DATA" ]; then


### PR DESCRIPTION
Some tests may fail on setup phase, when e.g. subscription-manager fails to register. Setting log level to debug will allow us to see logs from pytest-client-tools, and better investigate the cause for the failure.

Cherry-picked from 8f82241afe3d06e2d13748d143084d9f7f0a9138.

---

This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/343
