### PR TITLE
chore(test): Update path of files collected in archive

### DIFF
--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -115,7 +115,7 @@ def test_group(insights_client, tmp_path):
     with tarfile.open(archive_location, "r") as tar:
         dir_name = tar.getnames()[0]
         for m in tar.getmembers():
-            if m.name == f"{dir_name}/tags.json":
+            if m.name == f"{dir_name}/data/tags.json":
                 tag_file = tar.extractfile(m)
                 tag_file_content = json.load(tag_file)
                 break

--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -8,7 +8,6 @@
 
 import json
 import os
-import tarfile
 import pytest
 import conftest
 import glob
@@ -104,21 +103,14 @@ def test_group(insights_client, tmp_path):
             and value
     """
     group_name = "testing-group"
-    archive_name = "archive.tar.gz"
-    archive_location = tmp_path / archive_name
 
     # Running insights-client in offline mode to generate archive
     insights_client.run(
-        "--offline", f"--group={group_name}", f"--output-file={archive_location}"
+        "--offline", f"--group={group_name}", f"--output-dir={tmp_path}"
     )
 
-    with tarfile.open(archive_location, "r") as tar:
-        dir_name = tar.getnames()[0]
-        for m in tar.getmembers():
-            if m.name == f"{dir_name}/data/tags.json":
-                tag_file = tar.extractfile(m)
-                tag_file_content = json.load(tag_file)
-                break
+    with (tmp_path / "data/tags.json").open("r") as f:
+        tag_file_content: dict = json.load(f)
 
     assert len(tag_file_content) == 1
 

--- a/integration-tests/test_collection.py
+++ b/integration-tests/test_collection.py
@@ -299,8 +299,7 @@ def test_branch_info(insights_client, test_config, subman, tmp_path):
         2. The branch_info includes correct values
     """
     insights_client.run("--output-dir", tmp_path.absolute())
-    branch_info_path = tmp_path / "branch_info"
-    with branch_info_path.open("r") as file:
+    with (tmp_path / "data/branch_info").open("r") as file:
         data = json.load(file)
 
     if "satellite" in test_config.environment:
@@ -332,13 +331,8 @@ def test_archive_structure(insights_client, tmp_path):
         3. Expected subdirectories are present
     """
     archive_content = [
-        "blacklist_report",
-        "branch_info",
         "data",
-        "egg_release",
-        "insights_archive.txt",
         "meta_data",
-        "version_info",
     ]
 
     archive_data_content = [


### PR DESCRIPTION
The format of collected archive is being cleaned up, with most of the
files directly in the archive root being removed or moved.

File tags.json is present twice: at /tags.json and /data/tags.json. It's
been like that for a long time, we should be able to move the path of it
to always read /data/tags.json.

By replacing --output-file with --output-dir, we can omit manipulations
with the tar file.

---

This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)

* Card ID: CCT-1198
* Card ID: RHINENG-7581
