### PR TITLE
[el9] fix(test): Support running connection tests with proxy set

### DIFF
--- a/integration-tests/test_connection.py
+++ b/integration-tests/test_connection.py
@@ -12,7 +12,7 @@ import pytest
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
-def test_connection(insights_client):
+def test_connection_ok(insights_client):
     """
     :id: ff674d37-0ccc-481c-9f04-91237b8c50d0
     :title: Test connection


### PR DESCRIPTION
When HTTP_PROXY environment variable is set, and is pointing at valid
proxy server, these two tests would fail because insights-client reports
different errors on network errors for proxy/non-proxy scenarios.

This code takes proxies into account, and asserts strings accordingly.

---

This pull request is a backport of:
- https://github.com/RedHatInsights/insights-client/pull/346
- https://github.com/RedHatInsights/insights-client/pull/362

* Card ID: CCT-1199

