### PR TITLE
docs: Remove reference to argument for --diagnosis parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ These particular switches supersede normal client operation; they skip collectio
 - `--status` - Print the registration status.
 - `--payload=PAYLOAD` - Upload a specified file `PAYLOAD`. Requires `--content-type`
 - `--content-type=CONTENTTYPE` - Specify the console.redhat.com platform-specific content type for `--payload` option.
-- `--diagnosis=ID` - Retrieve remediations for this host, optionally providing a diagnosis ID.
+- `--diagnosis` - Retrieve a diagnosis for this host.
 - `--compliance` - Perform a compliance upload.
 - `--show-results` - Log the cached system profile to console. See also: `--check-results` under **Hidden switches**
 

--- a/docs/insights-client.8
+++ b/docs/insights-client.8
@@ -44,8 +44,8 @@ Specify a logfile other than the default.
 Skip collection and upload a specified archive. Requires --content-type.
 .IP "--content-type=TYPE"
 Content type of the archive specified with --payload.
-.IP "--diagnosis=ID"
-Retrieve a remediation for this system.
+.IP "--diagnosis"
+Retrieve a diagnosis for this host.
 .IP "--compliance"
 Scan the system with OpenSCAP and upload the report.
 .IP "--check-results"


### PR DESCRIPTION
* Card ID: CCT-226

Since the argument for the --diagnosis parameter was removed from insights-core code, it is no longer relevant to keep the reference to it in the documentation.

---

This pull request is a backport of: #356
