### PR TITLE
[el8] fix(test): Pass test_phase_error_100 even if no egg exists no the host

### DIFF
--- a/src/insights_client/tests/test_client.py
+++ b/src/insights_client/tests/test_client.py
@@ -1,11 +1,11 @@
-from unittest.mock import patch
+from unittest import mock
 import insights_client
 import pytest
 
 
 # Test config load error
-@patch("os.getuid", return_value=0)
-@patch(
+@mock.patch("os.getuid", return_value=0)
+@mock.patch(
     "insights.client.InsightsConfig.load_all", side_effect=ValueError("mocked error")
 )
 def test_load_config_error(os_uid, insightsConfig):
@@ -15,8 +15,8 @@ def test_load_config_error(os_uid, insightsConfig):
 
 
 # test keyboardinterrupt handler
-@patch("os.getuid", return_value=0)
-@patch("insights.client.InsightsConfig.load_all", side_effect=KeyboardInterrupt)
+@mock.patch("os.getuid", return_value=0)
+@mock.patch("insights.client.InsightsConfig.load_all", side_effect=KeyboardInterrupt)
 def test_keyboard_interrupt(os_uid, client):
     with pytest.raises(SystemExit) as sys_exit:
         insights_client._main()
@@ -24,13 +24,15 @@ def test_keyboard_interrupt(os_uid, client):
 
 
 # check run phase error 100 handler
-@patch("os.getuid", return_value=0)
-@patch("insights.client.phase.v1.get_phases")
-@patch("insights.client.InsightsClient")
-@patch("insights_client.subprocess.Popen")
-def test_phase_error_100(mock_subprocess, client, p, os_uid):
+@mock.patch("os.getuid", return_value=0)
+@mock.patch("insights.client.phase.v1.get_phases")
+@mock.patch("insights.client.InsightsClient")
+@mock.patch("insights_client.subprocess.Popen")
+def test_phase_error_100(mock_subprocess, client, phase, _os_getuid):
+    client.get_conf = mock.Mock(return_value={"gpg": False})
+
     with pytest.raises(SystemExit) as sys_exit:
         mock_subprocess.return_value.returncode = 100
         mock_subprocess.return_value.communicate.return_value = ("output", "error")
-        insights_client.run_phase(p, client, validated_eggs=[])
+        insights_client.run_phase(phase, client, validated_eggs=[])
     assert sys_exit.value.code == 0


### PR DESCRIPTION
* Card ID: CCT-1220

On systems where insights-client hasn't been run yet (e.g. pure container which only has the repository and test dependencies installed), the test fails because it never gets to the mocked section.

File existence and GPG validation in 'run_phase()' are only done if 'config.gpg' is set to True; mocking the attribute to read False skips these checks.

(cherry picked from commit 6f6337c39f9094cdd404d6a6a611160ee54822e7)

---

This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/364
