### PR TITLE
[el9] test: Change diagnosis expected output when unregistered

### DIFF
--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -12,6 +12,7 @@
 import json
 import os
 import pytest
+from pytest_client_tools.util import Version
 import conftest
 import glob
 
@@ -241,8 +242,10 @@ def test_client_diagnosis(insights_client):
         4. Verify the machine id in the diagnostic data matches the
             system's machine id
     :expectedresults:
-        1. The command fails with an error message indicating that diagnosis
-            data cannot be retrieved (404)
+        1. The command fails with a return code of 1. On systems with
+            version 3.5.7 or higher, the output includes message
+            'Could not get diagnosis data.'. Otherwise, the output
+            includes message 'Unable to get diagnosis data: 404'
         2. The client is registered
         3. The command retrieves diagnostic data and the output contains
             machine id
@@ -250,7 +253,11 @@ def test_client_diagnosis(insights_client):
     """
     # Running diagnosis on unregistered system returns appropriate error message
     diagnosis_result = insights_client.run("--diagnosis", check=False)
-    assert "Unable to get diagnosis data: 404" in diagnosis_result.stdout
+    assert diagnosis_result.returncode == 1
+    if insights_client.core_version >= Version(3, 5, 7):
+        assert "Could not get diagnosis data." in diagnosis_result.stdout
+    else:
+        assert "Unable to get diagnosis data: 404" in diagnosis_result.stdout
     # Running diagnosis on registered system
     insights_client.register()
     assert conftest.loop_until(lambda: insights_client.is_registered)


### PR DESCRIPTION
* Card ID: CCT-1195

When the host is not registered to insights-client, the output for diagnosis argument should not print out 404 error message. This change updates the failing integration test.

---

This pull request is a backport of: #363