### PR TITLE
[el8] test: Ensure that tests are part of evidence traceability matrix

### DIFF
--- a/integration-tests/custom_betelgeuse_config.py
+++ b/integration-tests/custom_betelgeuse_config.py
@@ -4,8 +4,14 @@ TESTCASE_CUSTOM_FIELDS = default_config.TESTCASE_CUSTOM_FIELDS + (
     "casecomponent",
     "subsystemteam",
     "reference",
+    "polarionincludeskipped",
+    "polarionlookupmethod",
+    "polarionprojectid",
 )
 
 DEFAULT_CASECOMPONENT_VALUE = ""
 DEFAULT_SUBSYSTEMTEAM_VALUE = ""
 DEFAULT_REFERENCE_VALUE = ""
+POLARION_INCLUDE_SKIPED = ""
+POLARION_LOOKUP_METHOD = ""
+POLARION_PROJECT_ID = ""

--- a/integration-tests/test_checkin.py
+++ b/integration-tests/test_checkin.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_client.py
+++ b/integration-tests/test_client.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_client_systemd.py
+++ b/integration-tests/test_client_systemd.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_collection.py
+++ b/integration-tests/test_collection.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_common_specs.py
+++ b/integration-tests/test_common_specs.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_connection.py
+++ b/integration-tests/test_connection.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_display_name_option.py
+++ b/integration-tests/test_display_name_option.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_e2e.py
+++ b/integration-tests/test_e2e.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_file_workflow.py
+++ b/integration-tests/test_file_workflow.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_manpage.py
+++ b/integration-tests/test_manpage.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_motd.py
+++ b/integration-tests/test_motd.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_obfuscation.py
+++ b/integration-tests/test_obfuscation.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_redaction.py
+++ b/integration-tests/test_redaction.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_registration.py
+++ b/integration-tests/test_registration.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_tags.py
+++ b/integration-tests/test_tags.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_unregister.py
+++ b/integration-tests/test_unregister.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_upload.py
+++ b/integration-tests/test_upload.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_version.py
+++ b/integration-tests/test_version.py
@@ -1,6 +1,9 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
 :subsystemteam: sst_csi_client_tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/testimony.yml
+++ b/integration-tests/testimony.yml
@@ -1,0 +1,63 @@
+---
+Id:
+  casesensitive: false
+  required: true
+  type: string
+Polarion-Project-Id:
+  casesensitive: false
+  required: true
+  type: choice
+  choices:
+    - RHELSS
+Polarion-Include-Skipped:
+  casesensitive: false
+  required: true
+  type: string
+Polarion-Lookup-Method:
+  casesensitive: false
+  required: true
+  type: string
+Reference:
+  casesensitive: false
+  required: false
+  type: string
+CaseComponent:
+  casesensitive: false
+  required: true
+  type: string
+Requirement:
+  casesensitive: false
+  required: true
+  type: choice
+  choices:
+    - RHSS-291297
+SubSystemTeam:
+  casesensitive: false
+  required: true
+  type: choice
+  choices:
+    - sst_csi_client_tools
+CaseAutomation:
+  casesensitive: false
+  required: true
+  type: string
+Upstream:
+  casesensitive: false
+  type: string
+Title:
+  casesensitive: false
+  type: string
+Description:
+  casesensitive: false
+  required: true
+  type: string
+Tags:
+  casesensitive: true
+  required: true
+  type: choice
+  choices:
+    - Tier 1
+    - Tier 2
+    - Tier 3
+Steps: {}
+ExpectedResults: {}


### PR DESCRIPTION
Based on CCT-452 I have added the neccessary docstrings to the test classes and edited the testimony.yaml and custom betelgeuse config to accomodate these changes.

(cherry picked from commit c69dfce6ad4c8b05dd61c83bba78fa9d0e407877)

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->


This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/374


<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->
