### PR TITLE
[el8] test: Adding tests for compliance option

### DIFF
--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,3 +1,4 @@
 git+https://github.com/ptoscano/pytest-client-tools@main
 pyyaml
 pytest-subtests
+distro

--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -229,7 +229,7 @@ def test_client_checkin_offline(insights_client):
 def test_client_diagnosis(insights_client):
     """
     :id: 7659051f-0e87-4fd7-bc95-0152077fe67e
-    :title: test diagnosis option
+    :title: Test diagnosis option
     :description:
         This test verifies that on a registered system, the --diagnosis
         option retrieves the correct diagnostic information

--- a/integration-tests/test_compliance.py
+++ b/integration-tests/test_compliance.py
@@ -1,0 +1,93 @@
+"""
+:casecomponent: insights-client
+:requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
+:subsystemteam: sst_csi_client_tools
+:caseautomation: Automated
+:upstream: Yes
+"""
+
+import conftest
+import pytest
+import distro
+
+pytestmark = [
+    pytest.mark.usefixtures("register_subman"),
+    pytest.mark.skipif(
+        distro.id() != "rhel",
+        reason="Skipping tests because OS ID is not RHEL",
+        allow_module_level=True,
+    ),
+]
+
+
+def test_compliance_option(insights_client):
+    """
+    :id: caa8b3e1-9347-494c-a1f5-1fa670136834
+    :title: Test compliance option
+    :reference: https://issues.redhat.com/browse/CCT-1229
+    :description:
+        This test verifies that running the --compliance will not result in a failure
+    :tags: Tier 1
+    :steps:
+        1. Run insights-client with --compliance option
+        2. Register insights-client
+        3. Run insights-client with --compliance option
+    :expectedresults:
+        1. Command will fail with instructions for user to register
+        2. System is successfully registered
+        3. The output of the command either informs user that system is not associated
+            with any policies or the report will be successfully uploaded
+    """
+    compliance_before_registration = insights_client.run("--compliance", check=False)
+    assert compliance_before_registration.returncode == 1
+    assert (
+        "This host has not been registered. Use --register to register this host"
+        in compliance_before_registration.stdout
+    )
+
+    insights_client.register()
+    assert conftest.loop_until(lambda: insights_client.is_registered)
+
+    compliance_after_registration = insights_client.run("--compliance", check=False)
+    if compliance_after_registration.returncode == 1:
+        assert (
+            "System is not associated with any policies."
+            in compliance_after_registration.stdout
+        )
+    else:
+        assert "Successfully uploaded report" in compliance_after_registration.stdout
+
+
+def test_compliance_policies_option(insights_client):
+    """
+    :id: ad3a2073-3a2e-485e-bc7b-fede2111a06a
+    :title: Test compliance-policies option
+    :reference: https://issues.redhat.com/browse/CCT-1229
+    :description:
+        This test verifies that running the --compliance-policies
+        will not result in a failure
+    :tags: Tier 1
+    :steps:
+        1. Register insights-client
+        2. Run insights-client with --compliance-policies option
+    :expectedresults:
+        1. System is successfully registered
+        2. The output of the command either informs the user that system is not
+            assignable to any policy or ID of available policy is found and
+            displayed
+    """
+    insights_client.register()
+    assert conftest.loop_until(lambda: insights_client.is_registered)
+
+    compliance_policies = insights_client.run("--compliance-policies", check=False)
+    if compliance_policies.returncode == 1:
+        assert "System is not assignable to any policy." in compliance_policies.stdout
+        assert (
+            "Create supported policy using the Compliance web UI."
+            in compliance_policies.stdout
+        )
+    else:
+        assert "ID" in compliance_policies.stdout

--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -5,16 +5,20 @@ set -x
 # get to project root
 cd ../../../
 
-# Check for GitHub pull request ID and install build if needed.
-# This is for the downstream PR jobs.
-[ -z "${ghprbPullId+x}" ] || ./systemtest/copr-setup.sh
+# Check for bootc/image-mode deployments which should not run dnf
+if ! command -v bootc >/dev/null || bootc status | grep -q 'type: null'; then
+  # Check for GitHub pull request ID and install build if needed.
+  # This is for the downstream PR jobs.
+  [ -z "${ghprbPullId+x}" ] || ./systemtest/copr-setup.sh
 
-# Simulate the packit setup on downstream builds.
-# This is for ad-hoc and compose testing.
-rpm -q insights-client || ./systemtest/guest-setup.sh
+  # Simulate the packit setup on downstream builds.
+  # This is for ad-hoc and compose testing.
+  rpm -q insights-client || ./systemtest/guest-setup.sh
 
-dnf --setopt install_weak_deps=False install -y \
-  podman git-core python3-pip python3-pytest logrotate bzip2 zip
+  dnf --setopt install_weak_deps=False install -y \
+    podman git-core python3-pip python3-pytest logrotate bzip2 zip \
+    scap-security-guide openscap-scanner openscap
+fi
 
 # If this is an insightsCore PR build and sign the new egg.
 [ -z "${insightsCoreBranch+x}" ] || ./systemtest/insights-core-setup.sh


### PR DESCRIPTION
I have added 2 tests to test the --compliance and --compliance-policies options. I also had to add some requirements as they were not on the system originally but compliance depends on them.

CCT Card: CCT-1229

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->


This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/378

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->
