### PR TITLE
fix(test): --unregister does not delete inventory host

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Command line switches available and their explanations.
 These particular switches supersede normal client operation; they skip collection and exit after printing their necessary output.
 
 - `--version` - Print the versions of both the wrapper and egg, then exit.
-- `--unregister` - Unregister this system from the Insights API.
+- `--unregister` - Unregister this system.
 - `--display-name=DISPLAYNAME` - When used without `--register`, change the display name and exit.
 - `--validate` - Validate the format of the remove.conf file.
 - `--enable-schedule` - Enable the Insights systemd job.

--- a/docs/insights-client.8
+++ b/docs/insights-client.8
@@ -15,7 +15,7 @@ Show this help message and exit.
 .IP "--register"
 Register host to the Red Hat Insights service.
 .IP "--unregister"
-Unregister host from the Red Hat Insights service.
+Unregister host.
 .IP "--display-name=DISPLAYNAME"
 Display name to use for this host. May be used during registration.
 .IP "--group=GROUP"

--- a/integration-tests/test_unregister.py
+++ b/integration-tests/test_unregister.py
@@ -10,6 +10,7 @@
 """
 
 import pytest
+from pytest_client_tools.util import Version
 import conftest
 
 pytestmark = pytest.mark.usefixtures("register_subman")
@@ -30,18 +31,22 @@ def test_unregister(insights_client):
         3. Confirm the client is unregistered
     :expectedresults:
         1. The client registers successfully
-        2. Command outputs "Successfully unregistered from the
-            Red Hat Insights Service".
+        2. On systems with Insights Core version >= 3.5.11, the command outputs
+            "Successfully unregistered this host." Otherwise, the command
+            outputs "Successfully unregistered from the Red Hat Insights Service"
         3. Client unregistration is confirmed
     """
     insights_client.register()
     assert conftest.loop_until(lambda: insights_client.is_registered)
 
     unregistration_status = insights_client.run("--unregister")
-    assert (
-        "Successfully unregistered from the Red Hat Insights Service"
-        in unregistration_status.stdout
-    )
+    if insights_client.core_version >= Version(3, 5, 11):
+        assert "Successfully unregistered this host." in unregistration_status.stdout
+    else:
+        assert (
+            "Successfully unregistered from the Red Hat Insights Service"
+            in unregistration_status.stdout
+        )
     assert conftest.loop_until(lambda: not insights_client.is_registered)
 
 
@@ -62,8 +67,9 @@ def test_unregister_twice(insights_client):
         3. Attempt to unregister the client a second time
     :expectedresults:
         1. The client registers successfully
-        2. Command outputs "Successfully unregistered from the
-            Red Hat Insights Service"
+        2. On systems with Insights Core version >= 3.5.11, the command outputs
+            "Successfully unregistered this host." Otherwise, the command
+            outputs "Successfully unregistered from the Red Hat Insights Service"
         3. Command returns exit code 1 and outputs "This host is not registered,
             unregistration is not applicable."
     """
@@ -73,10 +79,14 @@ def test_unregister_twice(insights_client):
     # unregister once
     unregistration_status = insights_client.run("--unregister")
     assert conftest.loop_until(lambda: not insights_client.is_registered)
-    assert (
-        "Successfully unregistered from the Red Hat Insights Service"
-        in unregistration_status.stdout
-    )
+    if insights_client.core_version >= Version(3, 5, 11):
+        assert "Successfully unregistered this host." in unregistration_status.stdout
+    else:
+        assert (
+            "Successfully unregistered from the Red Hat Insights Service"
+            in unregistration_status.stdout
+        )
+
     # unregister twice
     unregistration_status = insights_client.run("--unregister", check=False)
     assert conftest.loop_until(lambda: not insights_client.is_registered)


### PR DESCRIPTION
* Card ID: CCT-870

Since the command for unregistration updates only local files without calling DELETE /hosts/UUID API endpoint, integration tests must be updated accordingly.

---
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)

Since [insights-core#4393](https://github.com/RedHatInsights/insights-core/pull/4393) was merged, this PR is ready for review.