### PR TITLE
fix(test): Adding docstrings and pytest tier marks to test_verifier.py

### DIFF
--- a/integration-tests/playbook_verifier/test_verifier.py
+++ b/integration-tests/playbook_verifier/test_verifier.py
@@ -1,7 +1,17 @@
+"""
+:casecomponent: insights-client
+:requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
+:subsystemteam: sst_csi_client_tools
+:caseautomation: Automated
+:upstream: Yes
+"""
+
 import pathlib
 import subprocess
 import sys
-
 import pytest
 from pytest_client_tools.util import Version
 
@@ -18,13 +28,21 @@ PLAYBOOK_DIRECTORY = pathlib.Path(__file__).parent.absolute() / "playbooks"
     ],
 )
 def test_official_playbook(insights_client, filename: str):
-    """insights-client contains playbook verifier application.
-
-    It is used by rhc-worker-playbook and rhc-worker-script to safely deliver
-    and run Red Hat signed playbooks.
-
-    In this test, the official playbooks are verified against the GPG key
-    the application ships.
+    """
+    :id: 3659e27f-3621-4591-b1c4-b5f0a277bb72
+    :title: Test playbook verifier
+    :description:
+        This test verifies the official playbooks against the GPG key
+        the application ships.
+    :tags: Tier 1
+    :steps:
+        1. Read playbook file content
+        2. Run insights-client verifier with playbook
+        3. Compare output to input
+    :expectedresults:
+        1. File content is correctly read and loaded into memory
+        2. Subprocess executes successfully without errors
+        3. Verifier's output matches original playbook content
     """
     if (
         sys.version_info >= (3, 12)

--- a/integration-tests/playbook_verifier/test_verifier.py
+++ b/integration-tests/playbook_verifier/test_verifier.py
@@ -27,6 +27,7 @@ PLAYBOOK_DIRECTORY = pathlib.Path(__file__).parent.absolute() / "playbooks"
         "bugs.yml",
     ],
 )
+@pytest.mark.tier1
 def test_official_playbook(insights_client, filename: str):
     """
     :id: 3659e27f-3621-4591-b1c4-b5f0a277bb72


### PR DESCRIPTION
I have forgot to add the latest changes - adding the traceability docstrings and pytest tier marks into the playbook-verifier test. In this PR I'm adding these changes to test_verifier.py as an effort for CCT-1247.

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->


This pull request should be also backported to following maintenance branches:

- `el8` (all of RHEL 8)

For RHEL9 I will add these changes into the open PR so there will be no need to backporting this to the RHEL9.


<!--
This pull request is a backport of: URL
-->


Card ID: CCT-1247

