### PR TITLE
fix(test): Extending duration of test runs

### DIFF
--- a/systemtest/tests/integration/main.fmf
+++ b/systemtest/tests/integration/main.fmf
@@ -1,3 +1,3 @@
 summary: Runs tmt tests
 test: ./test.sh
-duration: 2h
+duration: 3h


### PR DESCRIPTION
Some of the test run failed on the timeout, so I created this PR extending the duration of the test runs to 3 hours instead of 2 to prevent failures on timeout.

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->


This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)


<!--
This pull request is a backport of: URL
-->

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->
