### PR TITLE
[el9] fix(test): --unregister does not delete inventory host

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Command line switches available and their explanations.
 These particular switches supersede normal client operation; they skip collection and exit after printing their necessary output.
 
 - `--version` - Print the versions of both the wrapper and egg, then exit.
-- `--unregister` - Unregister this system from the Insights API.
+- `--unregister` - Unregister this system.
 - `--display-name=DISPLAYNAME` - When used without `--register`, change the display name and exit.
 - `--validate` - Validate the format of the remove.conf file.
 - `--enable-schedule` - Enable the Insights systemd job.

--- a/docs/insights-client.8
+++ b/docs/insights-client.8
@@ -15,7 +15,7 @@ Show this help message and exit.
 .IP "--register"
 Register host to the Red Hat Insights service.
 .IP "--unregister"
-Unregister host from the Red Hat Insights service.
+Unregister host.
 .IP "--display-name=DISPLAYNAME"
 Display name to use for this host. May be used during registration.
 .IP "--group=GROUP"


### PR DESCRIPTION
* Card ID: CCT-870

Since the command for unregistration updates only local files without calling DELETE /hosts/UUID API endpoint, integration tests must be updated accordingly.

---

This pull request is a backport of: #384
