### PR TITLE
[el8] fix(test): Adding docstrings and pytest tier marks to test_verifier.py

### DIFF
--- a/integration-tests/playbook_verifier/test_verifier.py
+++ b/integration-tests/playbook_verifier/test_verifier.py
@@ -1,7 +1,17 @@
+"""
+:casecomponent: insights-client
+:requirement: RHSS-291297
+:polarion-project-id: RHELSS
+:polarion-include-skipped: false
+:polarion-lookup-method: id
+:subsystemteam: sst_csi_client_tools
+:caseautomation: Automated
+:upstream: Yes
+"""
+
 import pathlib
 import subprocess
 import sys
-
 import pytest
 
 
@@ -21,13 +31,21 @@ PLAYBOOK_DIRECTORY = pathlib.Path(__file__).parent.absolute() / "playbooks"
 )
 @pytest.mark.tier1
 def test_official_playbook(filename: str):
-    """insights-client contains playbook verifier application.
-
-    It is used by rhc-worker-playbook and rhc-worker-script to safely deliver
-    and run Red Hat signed playbooks.
-
-    In this test, the official playbooks are verified against the GPG key
-    the application ships.
+    """
+    :id: 3659e27f-3621-4591-b1c4-b5f0a277bb72
+    :title: Test playbook verifier
+    :description:
+        This test verifies the official playbooks against the GPG key
+        the application ships.
+    :tags: Tier 1
+    :steps:
+        1. Read playbook file content
+        2. Run insights-client verifier with playbook
+        3. Compare output to input
+    :expectedresults:
+        1. File content is correctly read and loaded into memory
+        2. Subprocess executes successfully without errors
+        3. Verifier's output matches original playbook content
     """
     playbook_content: str = (PLAYBOOK_DIRECTORY / filename).read_text()
 

--- a/integration-tests/playbook_verifier/test_verifier.py
+++ b/integration-tests/playbook_verifier/test_verifier.py
@@ -19,6 +19,7 @@ PLAYBOOK_DIRECTORY = pathlib.Path(__file__).parent.absolute() / "playbooks"
         "compliance_openscap_setup.yml",
     ],
 )
+@pytest.mark.tier1
 def test_official_playbook(filename: str):
     """insights-client contains playbook verifier application.
 


### PR DESCRIPTION
Adding the traceability docstrings and pytest tier marks into the playbook-verifier test. In this PR I'm adding these changes to test_verifier.py as an effort for CCT-1247.

cherry-picked from: dd4855dd850ea6ff9e8aba759fdbf5edbdfa9179 and 3bbce1e440f706b67e4ae068c680e9debd5c1529

---
This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/387/ 