### PR TITLE
[el9] fix(test): Extending duration of test runs

### DIFF
--- a/systemtest/tests/integration/main.fmf
+++ b/systemtest/tests/integration/main.fmf
@@ -1,3 +1,3 @@
 summary: Runs tmt tests
 test: ./test.sh
-duration: 2h
+duration: 3h


### PR DESCRIPTION
Some of the test run failed on the timeout, so I created this PR extending the duration of the test runs to 3 hours instead of 2 to prevent failures on timeout.

Cherry-picked from b5e299125e2bb07277ff1d53617c86b6a474c6f9

---
This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/388/