### PR TITLE
[el8] feat(test): Adding pytest markers for tiers

### DIFF
--- a/integration-tests/test_checkin.py
+++ b/integration-tests/test_checkin.py
@@ -20,6 +20,7 @@ import conftest
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.tier2
 def test_ultralight_checkin(insights_client, test_config):
     """
     :id: c662fd5e-0751-45e4-8477-6b0d27f735ac
@@ -68,6 +69,7 @@ def test_ultralight_checkin(insights_client, test_config):
     assert updated_ts_after_checkin > updated_ts_before_checkin
 
 
+@pytest.mark.tier1
 def test_client_checkin_unregistered(insights_client):
     """
     :id: 91331995-20c2-4d44-8abe-74a3e7d28309

--- a/integration-tests/test_client.py
+++ b/integration-tests/test_client.py
@@ -18,6 +18,7 @@ import conftest
 
 
 @pytest.mark.usefixtures("register_subman")
+@pytest.mark.tier1
 def test_client_files_permission(insights_client):
     """
     :id: e793cf5e-1c25-4e31-93c9-6f0465f50cae
@@ -68,6 +69,7 @@ def rpm_ql_insights_client():
         "/etc/logrotate.d/insights-client",
     ],
 )
+@pytest.mark.tier1
 def test_client_rpm_mandatory_files(filename, rpm_ql_insights_client):
     """
     :id: c7d2edbe-ae78-47e0-9b3d-ae1634c0ac79
@@ -87,6 +89,7 @@ def test_client_rpm_mandatory_files(filename, rpm_ql_insights_client):
 
 
 @pytest.mark.usefixtures("register_subman")
+@pytest.mark.tier1
 def test_client_logfiles_mask(insights_client):
     """
     :id: 8f24500c-d0ff-4ab1-a2ae-3b99cbf68e36
@@ -111,6 +114,7 @@ def test_client_logfiles_mask(insights_client):
         assert oct(os.stat(logfile).st_mode & 0o777) == "0o600"
 
 
+@pytest.mark.tier1
 def test_client_logdir_permissions():
     """
     :id: 204b1d54-6d8f-4d87-9227-cf3924cc5bb8
@@ -127,6 +131,7 @@ def test_client_logdir_permissions():
 
 
 @pytest.mark.usefixtures("register_subman")
+@pytest.mark.tier1
 def test_verify_logrotate_feature(insights_client):
     """
     :id: 5442729f-c6bc-4322-aa17-facd538e9fc3
@@ -190,6 +195,7 @@ def test_verify_logrotate_feature(insights_client):
 
 
 @pytest.mark.usefixtures("register_subman")
+@pytest.mark.tier1
 def test_insights_details_file_exists(insights_client):
     """
     :id: 2ccc8e00-0e76-47fd-bdb2-27998c0094ab
@@ -220,6 +226,7 @@ def test_insights_details_file_exists(insights_client):
 
 
 @pytest.mark.usefixtures("register_subman")
+@pytest.mark.tier1
 def test_insights_directory_files(insights_client):
     """
     :id: 02072b65-9905-4426-96dc-76af6a73e14f

--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -21,6 +21,7 @@ pytestmark = pytest.mark.usefixtures("register_subman")
 ARCHIVE_CACHE_DIRECTORY = "/var/cache/insights-client"
 
 
+@pytest.mark.tier1
 def test_set_ansible_host_info(insights_client):
     """
     :id: 18fc9438-8f2e-40f7-88b8-b51f36c9c396
@@ -50,6 +51,7 @@ def test_set_ansible_host_info(insights_client):
     assert ret.returncode == 0
 
 
+@pytest.mark.tier1
 def test_no_upload(insights_client):
     """
     :id: e55b7148-8d71-406d-a0d0-c1157a455cd5
@@ -87,6 +89,7 @@ def test_no_upload(insights_client):
     assert len(archive_file_after) > len(archive_file_before)
 
 
+@pytest.mark.tier1
 def test_group(insights_client, tmp_path):
     """
     :id: 29215bcc-1276-43cc-b87b-48d75f458426
@@ -126,6 +129,7 @@ def test_group(insights_client, tmp_path):
     assert tag["value"] == group_name
 
 
+@pytest.mark.tier1
 def test_support(insights_client):
     """
     :id: 43dbe53c-c8ec-41f2-8f1f-2396f07272cb
@@ -154,6 +158,7 @@ def test_support(insights_client):
     assert "Support information collected in" in support_result.stdout
 
 
+@pytest.mark.tier1
 def test_client_validate_no_network_call(insights_client):
     """
     :id: 2ca44ace-efe6-471c-8a4d-f24c9a913233
@@ -202,6 +207,7 @@ def test_client_validate_no_network_call(insights_client):
         os.remove(tags_filename)
 
 
+@pytest.mark.tier1
 def test_client_checkin_offline(insights_client):
     """
     :id: 05803f81-ebd6-4d58-9061-4d0403d8d9fc
@@ -226,6 +232,7 @@ def test_client_checkin_offline(insights_client):
     assert "ERROR: Cannot check-in in offline mode." in checkin_result.stderr
 
 
+@pytest.mark.tier1
 def test_client_diagnosis(insights_client):
     """
     :id: 7659051f-0e87-4fd7-bc95-0152077fe67e
@@ -269,6 +276,7 @@ def test_client_diagnosis(insights_client):
     assert diagnosis_data["insights_id"] == machine_id
 
 
+@pytest.mark.tier1
 def test_check_show_results(insights_client):
     """
     :id: 82571026-af14-464c-b9ff-5c03ecfe77c9

--- a/integration-tests/test_client_systemd.py
+++ b/integration-tests/test_client_systemd.py
@@ -18,6 +18,7 @@ from pathlib import Path
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.tier1
 def test_data_upload_systemd_timer(insights_client, external_inventory):
     """
     :id: 6bbac679-cb37-47b1-9163-497f1a1758dd

--- a/integration-tests/test_collection.py
+++ b/integration-tests/test_collection.py
@@ -18,6 +18,7 @@ import conftest
 import uuid
 
 
+@pytest.mark.tier1
 def test_output_file_valid_parameters(insights_client, tmp_path):
     """
     :id: 011e38c7-c6dc-4c17-add4-d67f0775f5cd
@@ -48,6 +49,7 @@ def test_output_file_valid_parameters(insights_client, tmp_path):
     assert f"Collected data copied to {archive_name}.tar.gz" in cmd_result.stdout
 
 
+@pytest.mark.tier1
 def test_output_file_non_existing_path(insights_client):
     """
     :id: 003faa12-8daa-417b-83bb-71aaa80209b6
@@ -81,6 +83,7 @@ def test_output_file_non_existing_path(insights_client):
     )
 
 
+@pytest.mark.tier1
 def test_output_dir_without_specifying_a_path(insights_client):
     """
     :id: 63eb1ba0-b9dd-4185-b422-18325c12b503
@@ -103,6 +106,7 @@ def test_output_dir_without_specifying_a_path(insights_client):
     assert "ERROR: --output-file cannot be empty" in cmd_result.stderr
 
 
+@pytest.mark.tier1
 def test_output_specifying_both_dir_and_file(insights_client, tmp_path):
     """
     :id: a572654d-904c-410e-ba00-f7b63f910e53
@@ -132,6 +136,7 @@ def test_output_specifying_both_dir_and_file(insights_client, tmp_path):
     assert "Specify only one: --output-dir or --output-file." in cmd_result.stderr
 
 
+@pytest.mark.tier1
 def test_output_file_with_relative_path(insights_client):
     """
     :id: e1236f11-46c3-452c-81b8-3c61506e1841
@@ -159,6 +164,7 @@ def test_output_file_with_relative_path(insights_client):
     assert f"{relative_path} is a directory." in cmd_result.stderr
 
 
+@pytest.mark.tier1
 def test_output_dir_with_not_empty_directory(insights_client):
     """
     :id: 30384d37-92b4-4196-8423-0355b0cbef30
@@ -187,6 +193,7 @@ def test_output_dir_with_not_empty_directory(insights_client):
     )
 
 
+@pytest.mark.tier1
 def test_output_dir_creates_archive_for_directory(insights_client, tmp_path):
     """
     :id: 6a966179-3b61-4a74-8af4-68fa0c2c237e
@@ -216,6 +223,7 @@ def test_output_dir_creates_archive_for_directory(insights_client, tmp_path):
         os.remove(os.path.abspath(directory[0:-1] + ".tar.gz"))
 
 
+@pytest.mark.tier1
 def test_output_file_already_exists(insights_client, tmp_path):
     """
     :id: 36456352-da31-4633-872a-061c2045176a
@@ -248,6 +256,7 @@ def test_output_file_already_exists(insights_client, tmp_path):
 
 
 @pytest.mark.usefixtures("register_subman")
+@pytest.mark.tier2
 def test_cmd_timeout(insights_client):
     """
     :id: 0a55318c-28e0-4ca7-bdbf-3eb8c0d689ea
@@ -283,6 +292,7 @@ def test_cmd_timeout(insights_client):
 
 
 @pytest.mark.usefixtures("register_subman")
+@pytest.mark.tier2
 def test_branch_info(insights_client, test_config, subman, tmp_path):
     """
     :id: 22c7063c-e09d-4fdf-80ea-864a7027d2ee
@@ -314,6 +324,7 @@ def test_branch_info(insights_client, test_config, subman, tmp_path):
         assert data["remote_leaf"] == -1, "Incorrect remote_leaf value"
 
 
+@pytest.mark.tier1
 def test_archive_structure(insights_client, tmp_path):
     """
     :id: 7a78cf8f-ed32-4011-8d15-787231f867c9

--- a/integration-tests/test_common_specs.py
+++ b/integration-tests/test_common_specs.py
@@ -16,6 +16,7 @@ import pytest
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.tier1
 def test_common_specs(insights_client, tmp_path):
     """
     :id: 9010f731-ca05-4abb-b119-de9730b055c1

--- a/integration-tests/test_compliance.py
+++ b/integration-tests/test_compliance.py
@@ -23,6 +23,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.tier1
 def test_compliance_option(insights_client):
     """
     :id: caa8b3e1-9347-494c-a1f5-1fa670136834
@@ -61,6 +62,7 @@ def test_compliance_option(insights_client):
         assert "Successfully uploaded report" in compliance_after_registration.stdout
 
 
+@pytest.mark.tier1
 def test_compliance_policies_option(insights_client):
     """
     :id: ad3a2073-3a2e-485e-bc7b-fede2111a06a

--- a/integration-tests/test_connection.py
+++ b/integration-tests/test_connection.py
@@ -52,6 +52,7 @@ def _is_using_proxy(
     return False
 
 
+@pytest.mark.tier1
 def test_connection_ok(insights_client):
     """
     :id: ff674d37-0ccc-481c-9f04-91237b8c50d0
@@ -77,6 +78,7 @@ def test_connection_ok(insights_client):
     assert api_test in test_connection.stdout
 
 
+@pytest.mark.tier1
 def test_http_timeout(insights_client):
     """
     :id: 46c5fe2a-1553-4f2e-802d-fa10080c72df
@@ -109,6 +111,7 @@ def test_http_timeout(insights_client):
     assert "Traceback" not in output.stdout
 
 
+@pytest.mark.tier1
 def test_noauth_proxy_connection(insights_client, test_config):
     """
     :id: a4bcb7e6-c04f-49d2-8362-525124dc61d9
@@ -145,6 +148,7 @@ def test_noauth_proxy_connection(insights_client, test_config):
     assert api_test in test_connection.stdout
 
 
+@pytest.mark.tier1
 def test_auth_proxy_connection(insights_client, test_config):
     """
     :id: 0b3e91d6-3b8b-42c7-8f3b-f7ee1728c311
@@ -184,6 +188,7 @@ def test_auth_proxy_connection(insights_client, test_config):
     assert api_test in test_connection.stdout
 
 
+@pytest.mark.tier1
 def test_wrong_url_connection(insights_client):
     """
     :id: aa411b34-9af2-4759-ae05-756e9019c85e

--- a/integration-tests/test_display_name_option.py
+++ b/integration-tests/test_display_name_option.py
@@ -37,6 +37,7 @@ def create_random_string(n: int):
     return "".join(random.choices(string.ascii_letters, k=n))
 
 
+@pytest.mark.tier1
 def test_display_name(insights_client):
     """
     :id: 4758cb21-03b4-4334-852c-791b7c82b50a
@@ -74,6 +75,7 @@ def test_display_name(insights_client):
     assert conftest.loop_until(display_name_changed)
 
 
+@pytest.mark.tier1
 def test_register_with_display_name(insights_client):
     """
     :id: d127b2bf-2f6d-4b02-bb8e-99036bfc4291
@@ -106,6 +108,7 @@ def test_register_with_display_name(insights_client):
     assert unique_hostname == record["display_name"]
 
 
+@pytest.mark.tier1
 def test_register_twice_with_different_display_name(
     insights_client, test_config, subtests
 ):
@@ -168,6 +171,7 @@ def test_register_twice_with_different_display_name(
 
 
 @pytest.mark.parametrize("invalid_display_name", [create_random_string(201), ""])
+@pytest.mark.tier1
 def test_invalid_display_name(invalid_display_name, insights_client):
     """
     :id: 9cbdd1a6-9ee3-4799-baaf-15c3894ca55b
@@ -210,6 +214,7 @@ def test_invalid_display_name(invalid_display_name, insights_client):
     ), "display-name should remain unchanged when new display-name is rejected"
 
 
+@pytest.mark.tier2
 def test_display_name_disable_autoconfig_and_autoupdate(insights_client, test_config):
     """
     :id: 8cdbc0ff-42ba-41e8-bd3f-31550ccac081

--- a/integration-tests/test_e2e.py
+++ b/integration-tests/test_e2e.py
@@ -16,6 +16,7 @@ from pytest_client_tools.util import Version
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.tier1
 def test_insights_client_version_in_inventory(insights_client, external_inventory):
     """
     :id: 1d5d101e-94ad-4404-900f-f86a26450c3f

--- a/integration-tests/test_file_workflow.py
+++ b/integration-tests/test_file_workflow.py
@@ -25,6 +25,7 @@ import conftest
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.tier1
 def test_file_workflow_with_an_archive_with_only_one_canonical_fact(
     insights_client, tmp_path
 ):
@@ -80,6 +81,7 @@ def test_file_workflow_with_an_archive_with_only_one_canonical_fact(
     assert host_data.get("fqdn", None) is None
 
 
+@pytest.mark.tier1
 def test_file_workflow_with_an_archive_without_canonical_facts(
     insights_client, tmp_path
 ):
@@ -130,6 +132,7 @@ def test_file_workflow_with_an_archive_without_canonical_facts(
     "container" in os.environ.keys(),
     reason="Containers cannot change hostnames",
 )
+@pytest.mark.tier1
 def test_file_workflow_archive_update_host_info(insights_client, external_inventory):
     """
     :id: 336abff9-4263-4f1d-9448-2cd05d40a371

--- a/integration-tests/test_manpage.py
+++ b/integration-tests/test_manpage.py
@@ -47,6 +47,7 @@ import pytest
         "--version",
     ],
 )
+@pytest.mark.tier1
 def test_manpage(option):
     """
     :id: bd8dbda3-930e-4081-b318-1e88b25e26ef

--- a/integration-tests/test_motd.py
+++ b/integration-tests/test_motd.py
@@ -49,6 +49,7 @@ def delete_special_files():
 
 @pytest.mark.usefixtures("register_subman")
 @pytest.mark.usefixtures("delete_special_files")
+@pytest.mark.tier1
 def test_motd(insights_client):
     """
     :id: a66a93bb-bbd2-4db0-a2aa-2bb184b11187
@@ -89,6 +90,7 @@ def test_motd(insights_client):
 
 @pytest.mark.usefixtures("register_subman")
 @pytest.mark.usefixtures("delete_special_files")
+@pytest.mark.tier1
 def test_motd_dev_null(insights_client):
     """
     :id: 7d48df16-e1af-4158-8a33-1d2cbb9ed22d
@@ -126,6 +128,7 @@ def test_motd_dev_null(insights_client):
 
 
 @pytest.mark.usefixtures("delete_special_files")
+@pytest.mark.tier1
 def test_motd_message():
     """
     :id: 56d12383-f7bb-4dbe-899c-a1cbd2172a30

--- a/integration-tests/test_obfuscation.py
+++ b/integration-tests/test_obfuscation.py
@@ -18,6 +18,7 @@ import socket
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.tier1
 def test_ip_obfuscation(insights_client, tmp_path):
     """
     :id: 59c073f7-d207-42ae-85ee-a7a5d6fc6f8d
@@ -58,6 +59,7 @@ def test_ip_obfuscation(insights_client, tmp_path):
     assert not check_obfuscated_info(insights_client, tmp_path, system_ip)
 
 
+@pytest.mark.tier1
 def test_hostname_obfuscation(insights_client, tmp_path):
     """
     :id: 68196220-f633-4a40-8040-6924d0e71b46
@@ -98,6 +100,7 @@ def test_hostname_obfuscation(insights_client, tmp_path):
 
 
 @pytest.mark.parametrize("password_file", ["/etc/redhat-release", "/etc/hosts"])
+@pytest.mark.tier1
 def test_password_obfuscation(insights_client, tmp_path, password_file):
     """
     :id: ad3f22b2-8792-45fb-abdd-d29d58db5c41
@@ -159,6 +162,7 @@ def test_password_obfuscation(insights_client, tmp_path, password_file):
         "data/etc/dnf/modules.d/",
     ],
 )
+@pytest.mark.tier1
 def test_no_obfuscation_on_package_version(
     insights_client, tmp_path, package_info_file
 ):
@@ -195,6 +199,7 @@ def test_no_obfuscation_on_package_version(
                 assert "10.230.230" not in file_content.decode()
 
 
+@pytest.mark.tier1
 def test_no_obfuscation_on_display_name(insights_client, tmp_path):
     """
     :id: a5b73cba-928d-4e78-9792-6a667e5c4c2b

--- a/integration-tests/test_redaction.py
+++ b/integration-tests/test_redaction.py
@@ -100,6 +100,7 @@ def test_redaction_not_on_file(insights_client, tmp_path, not_removed_file):
 
 
 @pytest.mark.parametrize("removed_file", TEST_FILE)
+@pytest.mark.tier1
 def test_redaction_on_file(insights_client, tmp_path, removed_file):
     """
     :id: 849cc4ac-d45e-44b8-b307-797935085eda
@@ -132,6 +133,7 @@ def test_redaction_on_file(insights_client, tmp_path, removed_file):
     "container" in os.environ.keys(),
     reason="Containers cannot change hostnames",
 )
+@pytest.mark.tier1
 def test_redaction_on_pattern_hostname(insights_client, tmp_path):
     """
     :id: 641edf11-ace1-4a98-9fb4-198cf9e5e4d0

--- a/integration-tests/test_registration.py
+++ b/integration-tests/test_registration.py
@@ -19,6 +19,7 @@ from constants import MACHINE_ID_FILE
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.tier1
 def test_register(insights_client):
     """
     :id: 5371018d-7b4a-4535-9bf9-7a7e60a9ee4a
@@ -47,6 +48,7 @@ def test_register(insights_client):
     assert "View the Red Hat Insights console" in register_result.stdout
 
 
+@pytest.mark.tier1
 def test_register_auth_proxy(insights_client, test_config):
     """
     :id: 1387745b-59a1-4a90-8f6d-dee2afa4723c
@@ -87,6 +89,7 @@ def test_register_auth_proxy(insights_client, test_config):
     assert f"Proxy User: {proxy_user}" in register_result.stdout
 
 
+@pytest.mark.tier1
 def test_register_noauth_proxy(insights_client, test_config):
     """
     :id: cbde1ce7-97fc-48d4-85bb-955ca45c8862
@@ -120,6 +123,7 @@ def test_register_noauth_proxy(insights_client, test_config):
     assert f"CONF Proxy: {no_auth_proxy}" in register_result.stdout
 
 
+@pytest.mark.tier1
 def test_machineid_exists_only_when_registered(insights_client):
     """
     :id: 27440051-e0d3-452e-b052-070cddf65aa1
@@ -159,6 +163,7 @@ def test_machineid_exists_only_when_registered(insights_client):
     assert not os.path.exists(MACHINE_ID_FILE)
 
 
+@pytest.mark.tier1
 def test_machineid_changes_on_new_registration(insights_client):
     """
     :id: ada04c6f-c351-4018-92f0-f3f21b7d645a
@@ -197,6 +202,7 @@ def test_machineid_changes_on_new_registration(insights_client):
         assert machine_id_new != machine_id_old
 
 
+@pytest.mark.tier1
 def test_double_registration(insights_client):
     """
     :id: b1cf2516-aab9-438d-b4c0-42182c84fde9
@@ -239,6 +245,7 @@ def test_double_registration(insights_client):
         pytest.param(False),
     ],
 )
+@pytest.mark.tier1
 def test_register_group_option(insights_client, legacy_upload_value):
     """
     :id: 5213a950-e66f-4749-8a76-66b6d4ed9aa5
@@ -272,6 +279,7 @@ def test_register_group_option(insights_client, legacy_upload_value):
     assert register_group_option.returncode == 0
 
 
+@pytest.mark.tier1
 def test_registered_and_unregistered_files_are_created_and_deleted(insights_client):
     """
     :id: 6e692793-f9ae-4ccb-a9d6-813b6d9aa7c3

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -20,6 +20,7 @@ from time import sleep
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.tier1
 def test_status_registered(external_candlepin, insights_client):
     """
     :id: 624b01fc-e841-4c26-afd8-bb28eaf7fe75
@@ -51,6 +52,7 @@ def test_status_registered(external_candlepin, insights_client):
         assert "This host is registered.\n" == registration_status.stdout
 
 
+@pytest.mark.tier1
 def test_status_registered_only_locally(
     external_candlepin, insights_client, external_inventory
 ):
@@ -93,6 +95,7 @@ def test_status_registered_only_locally(
         assert "This host is unregistered.\n" == registration_status.stdout
 
 
+@pytest.mark.tier1
 def test_status_unregistered(external_candlepin, insights_client):
     """
     :id: aa37831a-a581-44db-a7c9-de8161767c7e

--- a/integration-tests/test_tags.py
+++ b/integration-tests/test_tags.py
@@ -19,6 +19,7 @@ from constants import TAGS_FILE
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.tier1
 def test_tags(insights_client, external_inventory, test_config):
     """
     :id: 3e9d5b76-7065-4ade-8397-5854a8fef83b

--- a/integration-tests/test_unregister.py
+++ b/integration-tests/test_unregister.py
@@ -16,6 +16,7 @@ import conftest
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.tier1
 def test_unregister(insights_client):
     """
     :id: ecaeeddc-4c8b-4f17-8d69-1c81d2c7c744
@@ -49,6 +50,7 @@ def test_unregister(insights_client):
     assert conftest.loop_until(lambda: not insights_client.is_registered)
 
 
+@pytest.mark.tier1
 def test_unregister_twice(insights_client):
     """
     :id: bfff1b33-5f19-42d2-a6ff-4598975873e5

--- a/integration-tests/test_upload.py
+++ b/integration-tests/test_upload.py
@@ -16,6 +16,7 @@ import conftest
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.tier1
 def test_upload_pre_collected_archive(insights_client, tmp_path):
     """
     :id: 9eba5a67-d013-4d43-98c7-c41ed38bcede
@@ -55,6 +56,7 @@ def test_upload_pre_collected_archive(insights_client, tmp_path):
     assert "Successfully uploaded report" in upload_result.stdout
 
 
+@pytest.mark.tier1
 def test_upload_wrong_content_type(insights_client, tmp_path):
     """
     :id: bb9ee84a-d262-4c42-ae16-9b45bf5a385c
@@ -100,6 +102,7 @@ def test_upload_wrong_content_type(insights_client, tmp_path):
     assert "Content type different from compression" in upload_result.stdout
 
 
+@pytest.mark.tier1
 def test_upload_too_large_archive(insights_client, tmp_path):
     """
     :id: bb9ee84a-d262-4c42-ae16-9b45bf5a385c
@@ -143,6 +146,7 @@ def test_upload_too_large_archive(insights_client, tmp_path):
         ("xz", ".xz"),
     ],
 )
+@pytest.mark.tier1
 def test_upload_compressor_options(
     insights_client,
     compressor,
@@ -185,6 +189,7 @@ def test_upload_compressor_options(
     assert "Successfully uploaded report" in upload_result.stdout
 
 
+@pytest.mark.tier1
 def test_retries(insights_client):
     """
     :id: dafeb86e-463e-42fd-88e5-4551f1ba8f66
@@ -232,6 +237,7 @@ def test_retries(insights_client):
     assert "All attempts to upload have failed!" in upload_result.stdout
 
 
+@pytest.mark.tier1
 def test_retries_not_happening_on_unrecoverable_errors(insights_client):
     """
     :id: 1d740d1c-e98b-4571-86ac-10a233ff65ce

--- a/integration-tests/test_version.py
+++ b/integration-tests/test_version.py
@@ -9,7 +9,10 @@
 :upstream: Yes
 """
 
+import pytest
 
+
+@pytest.mark.tier1
 def test_version(insights_client):
     """
     :id: 7ec671cb-39ae-4cda-b279-f05d7c835d5d

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    tier1: Mark a test to be Tier 1
+    tier2: Mark a test to be Tier 2
+    tier3: Mark a test to be Tier 3


### PR DESCRIPTION
I have added the pytest tier marks to the tests to be able to run tests from integration-tests based on the marks. I have registered the mark in the pytest.ini also. This work is being tracked in CCT-1249.

cherry-picked from: f706247afc2f9147a0ee710948bb2fed7f5243c2

---
This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/383/

* Card ID: CCT-1249