### PR TITLE
fix(test): Adding debug options to the test_common_specs

### DIFF
--- a/integration-tests/test_connection.py
+++ b/integration-tests/test_connection.py
@@ -98,7 +98,7 @@ def test_http_timeout(insights_client):
         3. The command fails with a return code of 1
         4. The output mentions timeout value
     """
-    insights_client.config.http_timeout = 0.1
+    insights_client.config.http_timeout = 0.001
     insights_client.config.save()
 
     output = insights_client.run("--test-connection", check=False)
@@ -107,7 +107,7 @@ def test_http_timeout(insights_client):
     if _is_using_proxy(insights_client.config):
         assert "timeout('timed out')" in output.stdout
     else:
-        assert "Read timed out. (read timeout=0.1)"
+        assert "Read timed out. (read timeout=0.001)"
     assert "Traceback" not in output.stdout
 
 


### PR DESCRIPTION
As part of the work done for CCT-1238 I have added the debugging options for this test to be able to catch error more efficiently in case of this test failing. We will now be able to also see why the test was actually failing and not just the error from the spec JSON. As a minor change I have also tried to reduce the http_timeout to make this test functional.

cherry-picked from e4f09a963ae2a45063edf77be694634b479e1666

---
This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/382

* Card ID: CCT-1238