### PR TITLE
fix(test): Fixing test_tags

### DIFF
--- a/integration-tests/test_tags.py
+++ b/integration-tests/test_tags.py
@@ -15,6 +15,7 @@ import contextlib
 import os
 import yaml
 from constants import TAGS_FILE
+from time import sleep
 
 pytestmark = pytest.mark.usefixtures("register_subman")
 
@@ -68,6 +69,7 @@ def test_tags(insights_client, external_inventory, test_config):
             assert data_loaded["group"] == "first_tag"
 
         # Check new tag from inventory
+        sleep(30)
         system_tags = external_inventory.this_system_tags()
         assert {
             "namespace": "insights-client",
@@ -82,6 +84,7 @@ def test_tags(insights_client, external_inventory, test_config):
         with TAGS_FILE.open("w") as tags_yaml:
             yaml.dump(data_loaded, tags_yaml, default_flow_style=False)
         insights_client.run()
+        sleep(60)
         system_tags = external_inventory.this_system_tags()
         assert {
             "namespace": "insights-client",


### PR DESCRIPTION
test_tags was failing due to not having enough time for the changes to show in inventory. I have added the sleep function to wait 60 seconds before trying to get the inventory data back which then passed for me locally. This is a part of an effort for CCT-1238.

(cherry picked from commit 4baa863566f694bb7b164ba939a91fa1aed20092)

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->


This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/405


Card ID: CCT-1238

