### PR TITLE
[el8] fix(test): Fix archive connected tests

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -15,7 +15,7 @@ rpm -q insights-client || ./systemtest/guest-setup.sh
 
 dnf --setopt install_weak_deps=False install -y \
   podman git-core python3-pip python3-pytest logrotate bzip2 zip \
-  scap-security-guide openscap-scanner openscap
+  scap-security-guide openscap-scanner openscap bzip2-devel
 
 # If this is an insightsCore PR build and sign the new egg.
 [ -z "${insightsCoreBranch+x}" ] || ./systemtest/insights-core-setup.sh


### PR DESCRIPTION
As part of a CCT-1107 I have edited 3 different tests that are connected to the archive creation / upload. I have removed the parts that are connected to inventory more than the client side and therefore we won't have to edit the tests every time core or inventory teams change something in future. It now tests the client side only - creation of the archive and that the archive is able to be uploaded. I have also added the dependencies for the bz2 compressor as the test was failing due to missing them. I have also changed checking of display_name to fqdn. This makes the test more reliable in CI environments by comparing the system's fully qualified domain name (FQDN) from the inventory instead of display_name, which can differ based on system or setup.

(cherry picked from commit 171184f0ce604bc95e02f5ecbd3eb52204727fb0)

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->

This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/404

Card ID: CCT-1107

