### PR TITLE
fix(test): Fixing betelgeuse docstrings

### DIFF
--- a/integration-tests/playbook_verifier/test_verifier.py
+++ b/integration-tests/playbook_verifier/test_verifier.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """
@@ -32,6 +32,7 @@ def test_official_playbook(insights_client, filename: str):
     """
     :id: 3659e27f-3621-4591-b1c4-b5f0a277bb72
     :title: Test playbook verifier
+    :parametrized: yes
     :description:
         This test verifies the official playbooks against the GPG key
         the application ships.

--- a/integration-tests/test_checkin.py
+++ b/integration-tests/test_checkin.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_client.py
+++ b/integration-tests/test_client.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """
@@ -74,6 +74,7 @@ def test_client_rpm_mandatory_files(filename, rpm_ql_insights_client):
     """
     :id: c7d2edbe-ae78-47e0-9b3d-ae1634c0ac79
     :title: Verify mandatory files for RPM
+    :parametrized: yes
     :description: Verify the existence of mandatory files for the insights-client RPM
     :tags: Tier 1
     :steps:

--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_client_systemd.py
+++ b/integration-tests/test_client_systemd.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_collection.py
+++ b/integration-tests/test_collection.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_common_specs.py
+++ b/integration-tests/test_common_specs.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_compliance.py
+++ b/integration-tests/test_compliance.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_connection.py
+++ b/integration-tests/test_connection.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_display_name_option.py
+++ b/integration-tests/test_display_name_option.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """
@@ -173,6 +173,7 @@ def test_invalid_display_name(invalid_display_name, insights_client):
     """
     :id: 9cbdd1a6-9ee3-4799-baaf-15c3894ca55b
     :title: Test handling of invalid display names
+    :parametrized: yes
     :description:
         This test verifies that attempting to set an invalid display_name is rejected
         and does not alter the current display_name value

--- a/integration-tests/test_e2e.py
+++ b/integration-tests/test_e2e.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_file_workflow.py
+++ b/integration-tests/test_file_workflow.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_manpage.py
+++ b/integration-tests/test_manpage.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """
@@ -50,6 +50,7 @@ def test_manpage(option):
     """
     :id: bd8dbda3-930e-4081-b318-1e88b25e26ef
     :title: Test manual page entries for insights-client
+    :parametrized: yes
     :description:
         This test verifies that the insights-client manual page includes
         all the specified options.

--- a/integration-tests/test_motd.py
+++ b/integration-tests/test_motd.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_obfuscation.py
+++ b/integration-tests/test_obfuscation.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """
@@ -103,6 +103,7 @@ def test_password_obfuscation(insights_client, tmp_path, password_file):
     """
     :id: ad3f22b2-8792-45fb-abdd-d29d58db5c41
     :title: Test password obfuscation in collected files
+    :parametrized: yes
     :description:
         This test ensures that sensitive information such as passwords is obfuscated
         in collected files, regardless of the obfuscation setting in the configuration
@@ -166,6 +167,7 @@ def test_no_obfuscation_on_package_version(
     """
     :id: aa2eb4cf-9fed-4fe9-8423-87bbf2f2dd95
     :title: Test package versions are not obfuscated when obfuscation is enabled
+    :parametrized: yes
     :description:
         This test ensures that version strings in package information files
         are not incorrectly obfuscated as IP addresses when obfuscation is

--- a/integration-tests/test_redaction.py
+++ b/integration-tests/test_redaction.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """
@@ -29,6 +29,7 @@ def test_redaction_not_on_cmd(insights_client, tmp_path, not_removed_command):
     """
     :id: 264d1d8f-47a5-49ce-800c-d349aaacdb01
     :title: Test commands are collected when redaction not configured
+    :parametrized: yes
     :description:
         This test verifies that when no commands are configured for redaction in
         `/etc/insights-client/file-redaction.yaml`, the outputs of the related
@@ -51,6 +52,7 @@ def test_redaction_on_cmd(insights_client, tmp_path, removed_command):
     """
     :id: a2d7b71c-205d-4545-8a6b-b0be9ff57611
     :title: Test commands are redacted when configured
+    :parametrized: yes
     :description:
         This test verifies that when commands are configured for redaction in
         `/etc/insights-client/file-redaction.yaml`, the outputs of the related
@@ -79,6 +81,7 @@ def test_redaction_not_on_file(insights_client, tmp_path, not_removed_file):
     """
     :id: cb2ee8b8-fd82-48ad-bebc-3e044f277c55
     :title: Test files are collected when redaction not configured
+    :parametrized: yes
     :description:
         This test verifies that when no files are configured for redaction in
         `/etc/insights-client/file-redaction.yaml`, the related files are
@@ -102,6 +105,7 @@ def test_redaction_on_file(insights_client, tmp_path, removed_file):
     """
     :id: 849cc4ac-d45e-44b8-b307-797935085eda
     :title: Test files are redacted when configured
+    :parametrized: yes
     :description:
         This test verifies that when files are configured for redaction in
         `/etc/insights-client/file-redaction.yaml`, the related files are

--- a/integration-tests/test_registration.py
+++ b/integration-tests/test_registration.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """
@@ -244,6 +244,7 @@ def test_register_group_option(insights_client, legacy_upload_value):
     """
     :id: 5213a950-e66f-4749-8a76-66b6d4ed9aa5
     :title: Test register with --group option
+    :parametrized: yes
     :description:
         This test verifies that the --register command works as expected when
         --group option is used

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_tags.py
+++ b/integration-tests/test_tags.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_unregister.py
+++ b/integration-tests/test_unregister.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_upload.py
+++ b/integration-tests/test_upload.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """
@@ -155,6 +155,7 @@ def test_upload_compressor_options(
     """
     :id: 69a06826-6093-46de-a7a6-9726ae141820
     :title: Test upload with Different Compressor Options
+    :parametrized: yes
     :description:
         This test verifies that valid compression types can be used
         with --compressor to create archives and upload data using --payload

--- a/integration-tests/test_version.py
+++ b/integration-tests/test_version.py
@@ -4,7 +4,7 @@
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/testimony.yml
+++ b/integration-tests/testimony.yml
@@ -36,7 +36,11 @@ SubSystemTeam:
   required: true
   type: choice
   choices:
-    - sst_csi_client_tools
+    - rhel-sst-csi-client-tools
+Parametrized:
+  casesensitive: false
+  required: false
+  type: string
 CaseAutomation:
   casesensitive: false
   required: true


### PR DESCRIPTION
While uploading to Polarion I have figured that some of the docstrings we are using are wrong - I have changed the sst group and when the test have parameters I have added :parametrized:. I have added this ield also to testimony.yml so that we are checking for this field also. Another part of effort for CCT-1090.

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->


This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)



<!--
This pull request is a backport of: URL
-->



Card ID: CCT-1090

## Summary by Sourcery

Update test metadata and schema to correct subsystem team identifiers and support parameterized tests documentation

Enhancements:
- Standardize the :subsystemteam: tag from 'sst_csi_client_tools' to 'rhel-sst-csi-client-tools' across all integration tests
- Add a new ':parametrized:' docstring field set to 'yes' for tests with parameters
- Extend testimony.yml to include the optional 'Parametrized' field and update SubSystemTeam choices accordingly