### PR TITLE
fix(scripts): Do not pull egg on 4xx/5xx

### DIFF
--- a/scripts/01-upgrade-egg.sh
+++ b/scripts/01-upgrade-egg.sh
@@ -18,5 +18,5 @@ done
 
 TAG=$(cat EGG_VERSION)
 
-curl -L https://console.redhat.com/api/v1/static/release/insights-core.el10.egg --output data/rpm.egg
-curl -L https://console.redhat.com/api/v1/static/release/insights-core.el10.egg.asc --output data/rpm.egg.asc
+curl --fail -L https://console.redhat.com/api/v1/static/release/insights-core.el10.egg --output data/rpm.egg
+curl --fail -L https://console.redhat.com/api/v1/static/release/insights-core.el10.egg.asc --output data/rpm.egg.asc


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Add --fail flag to curl commands in 01-upgrade-egg.sh to abort on HTTP 4xx/5xx errors and avoid pulling invalid files