### PR TITLE
fix(test): Installing RPM builds for downstream Gating Jobs.

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -20,6 +20,13 @@ if ! command -v bootc >/dev/null || bootc status | grep -q 'type: null'; then
     scap-security-guide openscap-scanner openscap bzip2-devel
 fi
 
+# TEST_RPMS is set in jenkins jobs after parsing CI Messages in gating Jobs.
+# If TEST_RPMS is set then install the RPM builds for gating.
+if [[ -v TEST_RPMS ]]; then
+	echo "Installing RPMs: ${TEST_RPMS}"
+	dnf -y install --allowerasing ${TEST_RPMS}
+fi
+
 # If this is an insightsCore PR build and sign the new egg.
 [ -z "${insightsCoreBranch+x}" ] || ./systemtest/insights-core-setup.sh
 


### PR DESCRIPTION
This change affects downstream gating jobs only.
Currently jenkins uses tmt --last login option to install these builds during prepare phase, due to an issue #3716 in tmt our gate jobs are failing. With this change we will remove dependency on --last login and install the brew build directly.

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->

<!--
This pull request is a backport of: URL
-->

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->

## Summary by Sourcery

Fix downstream Jenkins gating jobs by bypassing tmt’s --last login and installing RPM builds directly from the TEST_RPMS environment variable.

Bug Fixes:
- Remove reliance on tmt’s --last login to install builds, preventing gating job failures.

Tests:
- Update integration test script to install RPMs via dnf when TEST_RPMS is defined.