### PR TITLE
test: Update log messages when unregistered

### DIFF
--- a/integration-tests/test_compliance.py
+++ b/integration-tests/test_compliance.py
@@ -45,7 +45,9 @@ def test_compliance_option(insights_client):
     compliance_before_registration = insights_client.run("--compliance", check=False)
     assert compliance_before_registration.returncode == 1
     assert (
-        "This host has not been registered. Use --register to register this host"
+        "This host is unregistered. Use --register to register this host"
+        in compliance_before_registration.stdout
+        or "This host has not been registered. Use --register to register this host"
         in compliance_before_registration.stdout
     )
 

--- a/integration-tests/test_registration.py
+++ b/integration-tests/test_registration.py
@@ -146,8 +146,10 @@ def test_machineid_exists_only_when_registered(insights_client):
 
     res = insights_client.run(check=False)
     assert (
-        "This host has not been registered. Use --register to register this host."
-    ) in res.stdout
+        "This host is unregistered. Use --register to register this host" in res.stdout
+        or "This host has not been registered. Use --register to register this host"
+        in res.stdout
+    )
     assert res.returncode != 0
     assert not os.path.exists(MACHINE_ID_FILE)
 


### PR DESCRIPTION
* Card ID: CCT-265

This patch updates the tests with logging messages that are shown to the user when the host is not registered. The changes made in [insights-core#4421](https://github.com/RedHatInsights/insights-core/pull/4421) (released in [insights-core-3.5.14](https://github.com/RedHatInsights/insights-core/compare/insights-core-3.5.13...insights-core-3.5.14)) changed the logging messages shown to the user.

---
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)