### PR TITLE
[el9] test: Update log messages when unregistered

### DIFF
--- a/integration-tests/test_compliance.py
+++ b/integration-tests/test_compliance.py
@@ -45,7 +45,9 @@ def test_compliance_option(insights_client):
     compliance_before_registration = insights_client.run("--compliance", check=False)
     assert compliance_before_registration.returncode == 1
     assert (
-        "This host has not been registered. Use --register to register this host"
+        "This host is unregistered. Use --register to register this host"
+        in compliance_before_registration.stdout
+        or "This host has not been registered. Use --register to register this host"
         in compliance_before_registration.stdout
     )
 

--- a/integration-tests/test_registration.py
+++ b/integration-tests/test_registration.py
@@ -150,8 +150,10 @@ def test_machineid_exists_only_when_registered(insights_client):
 
     res = insights_client.run(check=False)
     assert (
-        "This host has not been registered. Use --register to register this host."
-    ) in res.stdout
+        "This host is unregistered. Use --register to register this host" in res.stdout
+        or "This host has not been registered. Use --register to register this host"
+        in res.stdout
+    )
     assert res.returncode != 0
     assert not os.path.exists(MACHINE_ID_FILE)
 


### PR DESCRIPTION
* Card ID: CCT-265

This patch updates the tests with logging messages that are shown to the user when the host is not registered.

(cherry picked from commit 9690c034c57cbd9381b97cd714e3fc0312da6b7b)

---
This pull request is a backport of: #424

## Summary by Sourcery

Tests:
- Update registration and compliance tests to accept the new "This host is unregistered..." log message or fallback to the previous wording