### PR TITLE
fix(test): Extending duration of the tests runs

### DIFF
--- a/systemtest/tests/integration/main.fmf
+++ b/systemtest/tests/integration/main.fmf
@@ -1,3 +1,3 @@
 summary: Runs tmt tests
 test: ./test.sh
-duration: 3h
+duration: 5h


### PR DESCRIPTION
Some of the architectures like ppc64le or s390x are running on emulated systems - they are running on x86_64 with e.g. s390x emulated. This slows the execution of the tests which then usually fail on the timeout. Until that is solved and we have other arches available without having to emulate them we need to extend the duration of the test runs.

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->


This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)


<!--
This pull request is a backport of: URL
-->

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->
