### PR TITLE
[el9] fix(test): Extending duration of the tests runs for el9

### DIFF
--- a/systemtest/tests/integration/main.fmf
+++ b/systemtest/tests/integration/main.fmf
@@ -1,3 +1,3 @@
 summary: Runs tmt tests
 test: ./test.sh
-duration: 3h
+duration: 5h


### PR DESCRIPTION
Some of the architectures like ppc64le or s390x are running on emulated systems - they are running on x86_64 with e.g. s390x emulated. This slows the execution of the tests which then usually fail on the timeout. Until that is solved and we have other arches available without having to emulate them we need to extend the duration of the test runs.

(cherry picked from commit c6fbfc305a582097f7392c42f653616e7077e2c5)

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->


This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/427


<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->

## Summary by Sourcery

Extend the duration of system integration tests for EL9 to avoid CI failures on ppc64le and s390x when running under emulation.

Bug Fixes:
- Increase integration test duration to prevent timeouts on slower emulated architectures.

Tests:
- Extend systemtest integration timeout settings in main.fmf for EL9.

Chores:
- Backport timeout extension to the EL9 maintenance branch.