### PR TITLE
[el8] fix(test): Extending duration of the tests runs for el8

### DIFF
--- a/systemtest/tests/integration/main.fmf
+++ b/systemtest/tests/integration/main.fmf
@@ -1,3 +1,3 @@
 summary: Runs tmt tests
 test: ./test.sh
-duration: 3h
+duration: 5h


### PR DESCRIPTION
Some of the architectures like ppc64le or s390x are running on emulated systems - they are running on x86_64 with e.g. s390x emulated. This slows the execution of the tests which then usually fail on the timeout. Until that is solved and we have other arches available without having to emulate them we need to extend the duration of the test runs.

(cherry picked from commit https://github.com/RedHatInsights/insights-client/commit/c6fbfc305a582097f7392c42f653616e7077e2c5)

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->


This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/427


<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->

## Summary by Sourcery

Extend integration test durations on emulated architectures to prevent timeout failures and backport the changes to RHEL maintenance branches

Bug Fixes:
- Increase test run timeout for el8 integration tests to accommodate slower emulated architectures

Tests:
- Backport timeout extension to el7, el8, and el9 test suites