### PR TITLE
fix(test): Fixed test_check_show_results

### DIFF
--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -281,25 +281,23 @@ def test_check_show_results(insights_client):
         and displaying them (--show-results), a remediation is advised
     :tags: Tier 1
     :steps:
-        1. Register insights-client
-        2. Change permissions of /etc/ssh/sshd_config file to introduce a vulnerability
+        1. Change permissions of /etc/ssh/sshd_config file to introduce a vulnerability
+        2. Register insights-client
         3. Run insights-client with --check-results option
         4. Run the insights-client with --show-results option
     :expectedresults:
-        1. The client is registered
-        2. The permissions of the file are set to 0o777
+        1. The permissions of the file are set to 0o777
+        2. The client is registered
         3. The command runs successfully and checks for vulnerabilities
             retrieving the results
         4. The output includes a remediation for the OpenSSH config permission issue
     """
+    os.chmod("/etc/ssh/sshd_config", 0o777)
+
     insights_client.register()
     assert conftest.loop_until(lambda: insights_client.is_registered)
 
     try:
-        os.chmod("/etc/ssh/sshd_config", 0o777)
-
-        insights_client.run()
-
         insights_client.run("--check-results")
         show_results = insights_client.run("--show-results")
 


### PR DESCRIPTION
In order for insights-client to reliably check the correct results from Advisor we needed to change the order of action in the test. The permission of the file is changed before registering to insights so that there is enough time for the issue to be reflected in Advisor.

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->


This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)

<!--
This pull request is a backport of: URL
-->

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->

## Summary by Sourcery

Tests:
- Move os.chmod in test_check_show_results to before insights_client.register and remove redundant chmod and client.run call