### PR TITLE
[el9] fix(test): Fixing betelgeuse - polarion docstrings

### DIFF
--- a/integration-tests/custom_betelgeuse_config.py
+++ b/integration-tests/custom_betelgeuse_config.py
@@ -1,16 +1,16 @@
 from betelgeuse import default_config
 
 TESTCASE_CUSTOM_FIELDS = default_config.TESTCASE_CUSTOM_FIELDS + (
-    "casecomponent",
-    "subsystemteam",
+    "component",
+    "poolteam",
     "reference",
     "polarionincludeskipped",
     "polarionlookupmethod",
     "polarionprojectid",
 )
 
-DEFAULT_CASECOMPONENT_VALUE = ""
-DEFAULT_SUBSYSTEMTEAM_VALUE = ""
+DEFAULT_COMPONENT_VALUE = ""
+DEFAULT_POOLTEAM_VALUE = ""
 DEFAULT_REFERENCE_VALUE = ""
 POLARION_INCLUDE_SKIPED = ""
 POLARION_LOOKUP_METHOD = ""

--- a/integration-tests/playbook_verifier/test_verifier.py
+++ b/integration-tests/playbook_verifier/test_verifier.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_checkin.py
+++ b/integration-tests/test_checkin.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_client.py
+++ b/integration-tests/test_client.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_client_systemd.py
+++ b/integration-tests/test_client_systemd.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_collection.py
+++ b/integration-tests/test_collection.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_common_specs.py
+++ b/integration-tests/test_common_specs.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_compliance.py
+++ b/integration-tests/test_compliance.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_connection.py
+++ b/integration-tests/test_connection.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_display_name_option.py
+++ b/integration-tests/test_display_name_option.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_e2e.py
+++ b/integration-tests/test_e2e.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_file_workflow.py
+++ b/integration-tests/test_file_workflow.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_manpage.py
+++ b/integration-tests/test_manpage.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_motd.py
+++ b/integration-tests/test_motd.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_obfuscation.py
+++ b/integration-tests/test_obfuscation.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_redaction.py
+++ b/integration-tests/test_redaction.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_registration.py
+++ b/integration-tests/test_registration.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_tags.py
+++ b/integration-tests/test_tags.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_unregister.py
+++ b/integration-tests/test_unregister.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_upload.py
+++ b/integration-tests/test_upload.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/test_version.py
+++ b/integration-tests/test_version.py
@@ -1,10 +1,10 @@
 """
-:casecomponent: insights-client
+:component: insights-client
 :requirement: RHSS-291297
 :polarion-project-id: RHELSS
 :polarion-include-skipped: false
 :polarion-lookup-method: id
-:subsystemteam: sst_csi_client_tools
+:poolteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes
 """

--- a/integration-tests/testimony.yml
+++ b/integration-tests/testimony.yml
@@ -21,7 +21,7 @@ Reference:
   casesensitive: false
   required: false
   type: string
-CaseComponent:
+Component:
   casesensitive: false
   required: true
   type: string
@@ -31,7 +31,7 @@ Requirement:
   type: choice
   choices:
     - RHSS-291297
-SubSystemTeam:
+PoolTeam:
   casesensitive: false
   required: true
   type: choice


### PR DESCRIPTION
The fields we were using were Betelgeuse pre-filled fields, now I have changed the fields into what Polarion needs for a successful upload with the necessary fields included. This is a part of work for CCT-1090 for el9.

(cherry picked from commit 6f1517ed17af62916540151e8a14f6f455441293)

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->


This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/422



* Card ID: CCT-1090

## Summary by Sourcery

Replace Betelgeuse pre-filled fields with Polarion-required fields in tests and custom config to enable successful uploads.

Bug Fixes:
- Fix Polarion docstring tags in integration tests to use :component: and :poolteam: instead of deprecated Betelgeuse fields.

Enhancements:
- Update custom Betelgeuse configuration to include Polarion-specific fields (‘component’, ‘poolteam’, etc.) and their default values.

Tests:
- Revise testimony.yml schema entries to rename CaseComponent to Component and SubSystemTeam to PoolTeam.