### PR TITLE
[el8] fix(test): Fixed test_check_show_results

### DIFF
--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -304,8 +304,6 @@ def test_check_show_results(insights_client):
     assert conftest.loop_until(lambda: insights_client.is_registered)
 
     try:
-        insights_client.run()
-
         insights_client.run("--check-results")
         show_results = insights_client.run("--show-results")
 


### PR DESCRIPTION
In order for insights-client to reliably check the correct results from Advisor we needed to change the order of action in the test. The permission of the file is changed before registering to insights so that there is enough time for the issue to be reflected in Advisor.

(cherry picked from commit 92538eb0a705f29eb6800aa2aab17cde300b85df)

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->


This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/432


<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->
