### PR TITLE
[el8] fix(test): Fixing some architectural differences in tests

### DIFF
--- a/integration-tests/test_common_specs.py
+++ b/integration-tests/test_common_specs.py
@@ -18,6 +18,10 @@ import logging
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.skipif(
+    os.uname().machine != "x86_64",
+    reason="Test only runs on x86_64 architecture for now",
+)
 @pytest.mark.tier1
 def test_common_specs(insights_client, tmp_path):
     """

--- a/integration-tests/test_tags.py
+++ b/integration-tests/test_tags.py
@@ -20,6 +20,10 @@ from time import sleep
 pytestmark = pytest.mark.usefixtures("register_subman")
 
 
+@pytest.mark.skipif(
+    os.uname().machine != "x86_64",
+    reason="Test only runs on x86_64 architecture for now",
+)
 @pytest.mark.tier1
 def test_tags(insights_client, external_inventory, test_config):
     """


### PR DESCRIPTION
The test_tags and test_common_specs are currently not running on other architectures other than x86_64. This will need to be fixed some more in the future with better assert. For that we'll need systems not emulated but the exact architecture. Until then, as it is being worked on, we'll skip the tests for now.

(cherry picked from commit eafc474ace772afd264a59958aa5fc4b9b3717a7)

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->


This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/440/


<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->
