### PR TITLE
fix(docs/file-redaction.yaml.example): remove a tab char causing a trouble

### DIFF
--- a/docs/file-redaction.yaml.example
+++ b/docs/file-redaction.yaml.example
@@ -5,7 +5,7 @@
 
 # For a full list of files and commands run by insights-client,
 #   refer to /etc/insights-client/.fallback.json
- 	
+
 #	This file is deprecated and provided for compatibility only.
 #	It will be removed in a future version.
 


### PR DESCRIPTION
The original `docs/file-redaction.yaml.example` doesn't work well as it is because of the tab character at the beginning of the line.

```
  [root@rhel8 etc]# cp \
    /usr/share/doc/insights-client/file-redaction.yaml.example \
    /etc/insights-client/file-redaction.yal
  [root@rhel8 etc]# insights-client --no-upload
  ERROR: Cannot parse /etc/insights-client/file-redaction.yaml.
  If using any YAML tokens such as [] in an expression, be sure to \
  wrap the expression in quotation marks.

  Error details:
  while scanning for the next token
  found character '\t' that cannot start any token
    in "/etc/insights-client/file-redaction.yaml", line 3, column 1



```