### PR TITLE
[el8] fix(test): Fix Satellite failing tests

### DIFF
--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -22,7 +22,7 @@ ARCHIVE_CACHE_DIRECTORY = "/var/cache/insights-client"
 
 
 @pytest.mark.tier1
-def test_set_ansible_host_info(insights_client):
+def test_set_ansible_host_info(insights_client, test_config):
     """
     :id: 18fc9438-8f2e-40f7-88b8-b51f36c9c396
     :title: Test set ansible host info
@@ -41,6 +41,8 @@ def test_set_ansible_host_info(insights_client):
         2. The command completes successfully
         3. The return code is 0
     """
+    if "satellite615" in test_config.environment:
+        pytest.skip(reason="Issue was fixed in Satellite 6.16 and upwards")
     # Register system against Satellite, and register insights through satellite
     insights_client.register()
     assert conftest.loop_until(lambda: insights_client.is_registered)

--- a/integration-tests/test_compliance.py
+++ b/integration-tests/test_compliance.py
@@ -87,6 +87,11 @@ def test_compliance_policies_option(insights_client):
     assert conftest.loop_until(lambda: insights_client.is_registered)
 
     compliance_policies = insights_client.run("--compliance-policies", check=False)
+    if (
+        "An error has occurred while communicating with the API"
+        in compliance_policies.stdout
+    ):
+        pytest.skip(reason="Error communicating with API")
     if compliance_policies.returncode == 1:
         assert "System is not assignable to any policy." in compliance_policies.stdout
         assert (

--- a/integration-tests/test_display_name_option.py
+++ b/integration-tests/test_display_name_option.py
@@ -39,7 +39,7 @@ def create_random_string(n: int):
 
 
 @pytest.mark.tier1
-def test_display_name(insights_client):
+def test_display_name(insights_client, test_config):
     """
     :id: 4758cb21-03b4-4334-852c-791b7c82b50a
     :title: Test updating display name via '--display-name'
@@ -57,6 +57,8 @@ def test_display_name(insights_client):
         2. The command outputs 'Display name updated to <NEW_HOSTNAME>'
         3. The display_name in host detailes matches the new hostname
     """
+    if "satellite" in test_config.environment:
+        pytest.skip(reason="Test is not applicable to Satellite")
     new_hostname = generate_unique_hostname()
     insights_client.run("--register")
     assert conftest.loop_until(lambda: insights_client.is_registered)


### PR DESCRIPTION
Some tests were continuously failing when run against Satellite. The test_set_ansible_host_info was according to related CCT card not fixed on Satellite 6.15 and therefore should be skipped in that version. The test_compliance_policies_option was failing due to API communication troubles so in that case it will be also skipped. Based on some communications the test_display_name is not applicable on Satellite and therefore skipping it entirely if it run against it. This is the final part of CCT-1387.

(cherry picked from commit 0046638c6262a6ef6275ea9fce28718a243d8432)

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->

<!--
This pull request is a backport of: URL
-->

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->
