### PR TITLE
moving gating rpms install from jenkins to test suite

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -11,6 +11,13 @@ if ! command -v bootc >/dev/null || bootc status | grep -q 'type: null'; then
   # This is for the downstream PR jobs.
   [ -z "${ghprbPullId+x}" ] || ./systemtest/copr-setup.sh
 
+  # TEST_RPMS is set in jenkins jobs after parsing CI Messages in gating Jobs.
+  # If TEST_RPMS is set then install the RPM builds for gating.
+  if [[ -v TEST_RPMS ]]; then
+    echo "Installing RPMs: ${TEST_RPMS}"
+    dnf -y install --allowerasing ${TEST_RPMS}
+  fi
+
   # Simulate the packit setup on downstream builds.
   # This is for ad-hoc and compose testing.
   rpm -q insights-client || ./systemtest/guest-setup.sh


### PR DESCRIPTION
As part of testing-farm migration we need to do more test setup in this project and not Jenkins.  This exact setup is already being used by rhc.   Will need to be back-ported to all testing branches.