### PR TITLE
fix: Remove ls_dev from the test_common_specs

### DIFF
--- a/integration-tests/test_common_specs.py
+++ b/integration-tests/test_common_specs.py
@@ -51,7 +51,6 @@ def test_common_specs(insights_client, tmp_path):
         "insights.specs.Specs.date.json",
         "insights.specs.Specs.hosts.json",
         "insights.specs.Specs.installed_rpms.json",
-        "insights.specs.Specs.ls_dev.json",
         "insights.specs.Specs.lscpu.json",
         "insights.specs.Specs.lspci.json",
         "insights.specs.Specs.meminfo.json",


### PR DESCRIPTION
Collection for ls_dev spec was removed from core repository, which started causing failure of integration test for this spec. This commit removes that spec from the test_common_specs.

Failure of the test was caused by the change in [insights-core#4453](https://github.com/RedHatInsights/insights-core/pull/4453)

---
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)