### PR TITLE
[el9] fix: Remove ls_dev from the test_common_specs

### DIFF
--- a/integration-tests/test_common_specs.py
+++ b/integration-tests/test_common_specs.py
@@ -52,7 +52,6 @@ def test_common_specs(insights_client, tmp_path):
         "insights.specs.Specs.date.json",
         "insights.specs.Specs.hosts.json",
         "insights.specs.Specs.installed_rpms.json",
-        "insights.specs.Specs.ls_dev.json",
         "insights.specs.Specs.lscpu.json",
         "insights.specs.Specs.lspci.json",
         "insights.specs.Specs.meminfo.json",


### PR DESCRIPTION
Collection for ls_dev spec was removed from core repository, which started causing failure of integration test for this spec. This commit removes that spec from the test_common_specs.

(cherry picked from commit ab25a56f234c3fe6cf1176b9158e300fd2cf178b)

---
This pull request is a backport of: #467