### PR TITLE
fix(test): Remove fields now provided by Jenkins pipeline

### DIFF
--- a/integration-tests/custom_betelgeuse_config.py
+++ b/integration-tests/custom_betelgeuse_config.py
@@ -4,14 +4,8 @@ TESTCASE_CUSTOM_FIELDS = default_config.TESTCASE_CUSTOM_FIELDS + (
     "casecomponent",
     "subsystemteam",
     "reference",
-    "polarionincludeskipped",
-    "polarionlookupmethod",
-    "polarionprojectid",
 )
 
 DEFAULT_COMPONENT_VALUE = ""
 DEFAULT_POOLTEAM_VALUE = ""
 DEFAULT_REFERENCE_VALUE = ""
-POLARION_INCLUDE_SKIPED = ""
-POLARION_LOOKUP_METHOD = ""
-POLARION_PROJECT_ID = ""

--- a/integration-tests/playbook_verifier/test_verifier.py
+++ b/integration-tests/playbook_verifier/test_verifier.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_checkin.py
+++ b/integration-tests/test_checkin.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_client.py
+++ b/integration-tests/test_client.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_client_systemd.py
+++ b/integration-tests/test_client_systemd.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_collection.py
+++ b/integration-tests/test_collection.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_common_specs.py
+++ b/integration-tests/test_common_specs.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_compliance.py
+++ b/integration-tests/test_compliance.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_connection.py
+++ b/integration-tests/test_connection.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_display_name_option.py
+++ b/integration-tests/test_display_name_option.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_e2e.py
+++ b/integration-tests/test_e2e.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_file_workflow.py
+++ b/integration-tests/test_file_workflow.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_manpage.py
+++ b/integration-tests/test_manpage.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_motd.py
+++ b/integration-tests/test_motd.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_obfuscation.py
+++ b/integration-tests/test_obfuscation.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_redaction.py
+++ b/integration-tests/test_redaction.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_registration.py
+++ b/integration-tests/test_registration.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_ros.py
+++ b/integration-tests/test_ros.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_tags.py
+++ b/integration-tests/test_tags.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_unregister.py
+++ b/integration-tests/test_unregister.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_upload.py
+++ b/integration-tests/test_upload.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes

--- a/integration-tests/test_version.py
+++ b/integration-tests/test_version.py
@@ -1,9 +1,6 @@
 """
 :casecomponent: insights-client
 :requirement: RHSS-291297
-:polarion-project-id: RHELSS
-:polarion-include-skipped: false
-:polarion-lookup-method: id
 :subsystemteam: rhel-sst-csi-client-tools
 :caseautomation: Automated
 :upstream: Yes


### PR DESCRIPTION
These fields are now injected via the Jenkins pipeline, so we don't need to define them in the integration tests and related config. This removes duplication and avoids drift between CI and the test suite.

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->


This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)


<!--
This pull request is a backport of: URL
-->

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->
