### PR TITLE
chore: Drop GitHub Actions privileges

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,4 +1,6 @@
 name: codespell
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/docstring_validation.yml
+++ b/.github/workflows/docstring_validation.yml
@@ -1,5 +1,7 @@
 ---
 name: Test Docstrings Validation
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,6 @@
 name: pytest
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/stylish.yml
+++ b/.github/workflows/stylish.yml
@@ -1,4 +1,6 @@
 name: stylish
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Set 'permissions' block to modify access to the $GITHUB_TOKEN variable. Since all our existing workflows only read code and only produce a text output, we can limit quite a lot of it.

Permission 'contents' refers to the contents of the repository (such as listing the commits). All permissions not specified are implicitly set to 'none'.

Addresses GitHub's CodeQL rule 'actions/missing-workflow-permissions'.

More information at:
https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions

---

This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)

---

Disclaimer: Because of how GitHub permission system works, we'll see whether this breaks something only after we merge the PR.