### PR TITLE
[el9] fix: Correct version in spec file

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -6,7 +6,7 @@
 
 Name:                   insights-client
 Summary:                Uploads Insights information to Red Hat on a periodic basis
-Version:                {{{ git_dir_version lead=3.2 }}}
+Version:                {{{ git_dir_version lead=3.9 }}}
 Release:                0%{?dist}
 Source:                 {{{ git_dir_pack }}}
 License:                GPL-2.0-or-later


### PR DESCRIPTION
* Card ID: CCT-1113

The git_dir_version lead parameter in the .spec file was hardcoded to 3.2, which caused COPR builds to be tagged incorrectly. This commit updates the lead parameter to 3.9 to correctly detect the latest version of insights-client.

(cherry picked from commit 372bb82946fbc7ce559187b07644c1f87a6ac907)

---
This pull request is a backport of: #477 