### PR TITLE
ci: Add RHEL 10 to Packit

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -21,6 +21,7 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
+      - rhel-10
       - centos-stream-10-x86_64
       - centos-stream-10-aarch64
       - centos-stream-10-s390x
@@ -33,6 +34,7 @@ jobs:
     owner: "@yggdrasil"
     project: latest
     targets:
+      - rhel-10
       - centos-stream-10-x86_64
       - centos-stream-10-aarch64
       - centos-stream-10-s390x
@@ -69,7 +71,7 @@ jobs:
     trigger: pull_request
     identifier: "unit/rhel"
     targets:
-      centos-stream-10-x86_64: # TODO: Change back to RHEL
+      rhel-10-x86_64:
         distros:
           - RHEL-10-Nightly
     labels:


### PR DESCRIPTION
Since the last time this file has been updated (and older RHEL streams have been dropped because they have been branched), RHEL 10 has been released.
