### PR TITLE
feat: Add obfuscation_list option to the config file

### DIFF
--- a/data/insights-client.conf
+++ b/data/insights-client.conf
@@ -16,11 +16,9 @@
 # Automatically update the dynamic configuration
 #auto_update=True
 
-# Obfuscate IP addresses
-#obfuscate=False
-
-# Obfuscate hostname. Requires obfuscate=True.
-#obfuscate_hostname=False
+# Specify which data types should be obfuscated in the data collection
+# Supported options: ipv4, ipv6, hostname, mac (comma-separated list)
+#obfuscation_list=
 
 # Display name for registration
 #display_name=

--- a/docs/insights-client.conf.5
+++ b/docs/insights-client.conf.5
@@ -17,10 +17,8 @@ Base URL for API Interactions.
 URL for the proxy.
 .IP "auto_update=True"
 Automatically update the dynamic configuration.
-.IP "obfuscate=False"
-Obfuscate IP addresses.
-.IP "obfuscate_hostname=False"
-Obfuscate hostname. Requires obfuscate=True.
+.IP "obfuscation_list="
+Specify which data types should be obfuscated in the data collection.
 .IP "display_name="
 Display name for this system.
 .IP "ansible_host="


### PR DESCRIPTION
* Card ID: CCT-1576

To support the new configuration for IPv6 and MAC address obfuscation, this commit adds obfuscation_list option and removes the old obfuscate options in the configuration file. Also this commit updates manpage for the configuration file to reflect this change.

---
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)