### PR TITLE
[el9] fix(test): Fix Satellite version skip

### DIFF
--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -38,7 +38,10 @@ def test_set_ansible_host_info(insights_client, test_config):
         2. The command completes successfully
         3. The return code is 0
     """
-    if "satellite615" in test_config.environment:
+    if (
+        "satellite614" in test_config.environment
+        or "satellite615" in test_config.environment
+    ):
         pytest.skip(reason="Issue was fixed in Satellite 6.16 and upwards")
     # Register system against Satellite, and register insights through satellite
     insights_client.register()


### PR DESCRIPTION
As we are now running tests on Satellite 6.14 as well, we needed to broaden the exception in test_set_ansible_host_info as the issue was fixed in Satellite 6.16 and upwards.

(cherry picked from commit 6832bf2c5cfb4948c1337d4891919b470371c788)

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->

<!--
This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)
- `el7` (all of RHEL 7)
-->

This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/496/


<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->
