### PR TITLE
fix(test): Disable beaker-tasks repo in insights-client-ros installation

### DIFF
--- a/integration-tests/test_ros.py
+++ b/integration-tests/test_ros.py
@@ -35,7 +35,9 @@ def test_ros_install():
         2. Field ros_collect is set to true in insights-client.conf
     """
     install = subprocess.run(
-        ["dnf", "install", "-y", PACKAGE], capture_output=True, text=True
+        ["dnf", "install", "-y", "--disablerepo", "beaker-tasks", PACKAGE],
+        capture_output=True,
+        text=True,
     )
     assert install.returncode == 0, f"{PACKAGE} was not installed"
 


### PR DESCRIPTION
Add --disablerepo beaker-tasks to dnf install command to prevent using the beaker-tasks repository when installing insights-client-ros package during test execution.

---
<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->


This pull request should be also backported to following maintenance branches:

- `el9` (all of RHEL 9)
- `el8` (all of RHEL 8)

<!--
This pull request is a backport of: URL
-->

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->
