### PR TITLE
chore: Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,19 +1,19 @@
----
-<!-- Depending on the PR, uncomment appropriate blocks and fill in the details. -->
-
-<!--
-This pull request should be also backported to following maintenance branches:
-
-- `el9` (all of RHEL 9)
-- `el8` (all of RHEL 8)
-- `el7` (all of RHEL 7)
--->
-
-<!--
-This pull request is a backport of: URL
--->
-
 <!--
 * Card ID: RHEL-xxxx
 * Card ID: CCT-xxxx
+-->
+
+---
+
+<!-- Uncomment this when opening a pull request against 'main' branch.
+This pull request should be also backported to following maintenance branches:
+
+- `rhel-10-egg` (RHEL <= 10.1)
+- `rhel-9-main` (RHEL >= 9.8)
+- `rhel-9-egg` (RHEL <= 9.7)
+- `rhel-8-egg` (RHEL 8)
+-->
+
+<!-- Uncomment this when opening a pull request against 'rhel-*' branch.
+This pull request is a backport of: URL
 -->


### PR DESCRIPTION
To reflect changes in insights-core packaging, updating the pull request template to follow streams of work: branches `main` and `rhel-10-main` track insights-core as an RPM dependency, while `rhel-*-egg` branches still package it as a zip file and download its updates from CDN.
