### PR TITLE
chore: Update Packit configuration for COPR builds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "master"
+    target-branch: "main"
     commit-message:
       prefix: "ci"

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -30,7 +30,7 @@ jobs:
 
   - job: copr_build
     trigger: commit
-    branch: master
+    branch: main
     owner: "@yggdrasil"
     project: latest
     targets:


### PR DESCRIPTION
* Card ID: CCT-1620

With the branch name changes, we need to change from where we build.

- `rhel-9-main` (RHEL >= 9.8)
