### PR TITLE
[rhel-10-egg] chore: Drop Fedora CI configuration

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -14,10 +14,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Fedora Rawhide"
-            image: "registry.fedoraproject.org/fedora:rawhide"
-          - name: "Fedora Latest"
-            image: "registry.fedoraproject.org/fedora:latest"
           - name: "CentOS Stream 10"
             image: "quay.io/centos/centos:stream10"
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,7 +26,6 @@ jobs:
       - centos-stream-10-aarch64
       - centos-stream-10-s390x
       - centos-stream-10-ppc64le
-      - fedora-all
 
   - job: copr_build
     trigger: commit
@@ -39,7 +38,6 @@ jobs:
       - centos-stream-10-aarch64
       - centos-stream-10-s390x
       - centos-stream-10-ppc64le
-      - fedora-all
 
   - job: tests
     trigger: pull_request
@@ -53,19 +51,6 @@ jobs:
         - artifacts:
             - type: repository-file
               id: https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/centos-stream-$releasever/group_yggdrasil-latest-centos-stream-$releasever.repo
-
-  - job: tests
-    trigger: pull_request
-    identifier: "unit/fedora"
-    targets:
-      - fedora-all
-    labels:
-      - unit
-    tf_extra_params:
-      environments:
-        - artifacts:
-            - type: repository-file
-              id: https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/fedora-$releasever/group_yggdrasil-latest-fedora-$releasever.repo
 
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
* Card ID: CCT-1597

This commit drops the Fedora pipelines since insights-client is not a primary tool on Fedora and is not widely supported on that platform.

(cherry picked from commit 2e364abb6f250e2f0e3dba763c41b0f2ab6541fc)

---

This pull request is a backport of: #511 
