### PR TITLE
feat(test): Add selinux_context=None for user-invoked functionality t…

### DIFF
--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -149,7 +149,7 @@ def test_support(insights_client):
             'last successful upload', 'connectivity tests', 'running command',
             'process output' and 'support information collected'
     """
-    support_result = insights_client.run("--support")
+    support_result = insights_client.run("--support", selinux_context=None)
 
     assert "Insights version:" in support_result.stdout
     assert "Registration check:" in support_result.stdout
@@ -196,7 +196,7 @@ def test_client_validate_no_network_call(insights_client):
         insights_client.config.auto_config = False
         insights_client.config.auto_update = False
 
-        validate_result = insights_client.run("--validate")
+        validate_result = insights_client.run("--validate", selinux_context=None)
 
         # validating tags.yaml is loaded and no metric data in output
         assert (
@@ -261,7 +261,9 @@ def test_client_diagnosis(insights_client):
         4. The machine ID in the diagnostic data matches the system's machine id
     """
     # Running diagnosis on unregistered system returns appropriate error message
-    diagnosis_result = insights_client.run("--diagnosis", check=False)
+    diagnosis_result = insights_client.run(
+        "--diagnosis", check=False, selinux_context=None
+    )
     assert diagnosis_result.returncode == 1
     if insights_client.core_version >= Version(3, 5, 7):
         assert "Could not get diagnosis data." in diagnosis_result.stdout

--- a/integration-tests/test_collection.py
+++ b/integration-tests/test_collection.py
@@ -284,7 +284,7 @@ def test_cmd_timeout(insights_client):
     insights_client.config.cmd_timeout = 10
     insights_client.config.save()
 
-    timeout_output = insights_client.run("--verbose", check=False)
+    timeout_output = insights_client.run("--verbose", check=False, selinux_context=None)
     assert cmd_output_message in timeout_output.stdout
 
 

--- a/integration-tests/test_connection.py
+++ b/integration-tests/test_connection.py
@@ -70,7 +70,7 @@ def test_connection_ok(insights_client):
     url_test = "End Upload URL Connection Test: SUCCESS"
     api_test = "End API URL Connection Test: SUCCESS"
 
-    test_connection = insights_client.run("--test-connection")
+    test_connection = insights_client.run("--test-connection", selinux_context=None)
     assert url_test in test_connection.stdout
     assert api_test in test_connection.stdout
 
@@ -98,7 +98,7 @@ def test_http_timeout(insights_client):
     insights_client.config.http_timeout = 0.001
     insights_client.config.save()
 
-    output = insights_client.run("--test-connection", check=False)
+    output = insights_client.run("--test-connection", check=False, selinux_context=None)
     assert output.returncode == 1
 
     if _is_using_proxy(insights_client.config):
@@ -140,7 +140,7 @@ def test_noauth_proxy_connection(insights_client, test_config):
     insights_client.config.proxy = no_auth_proxy
     insights_client.config.save()
 
-    test_connection = insights_client.run("--test-connection")
+    test_connection = insights_client.run("--test-connection", selinux_context=None)
     assert url_test in test_connection.stdout
     assert api_test in test_connection.stdout
 
@@ -180,7 +180,7 @@ def test_auth_proxy_connection(insights_client, test_config):
     )
     insights_client.config.proxy = auth_proxy
     insights_client.config.save()
-    test_connection = insights_client.run("--test-connection")
+    test_connection = insights_client.run("--test-connection", selinux_context=None)
     assert url_test in test_connection.stdout
     assert api_test in test_connection.stdout
 
@@ -213,7 +213,9 @@ def test_wrong_url_connection(insights_client):
     insights_client.config.authmethod = "CERT"
     insights_client.config.save()
 
-    test_connection = insights_client.run("--test-connection", check=False)
+    test_connection = insights_client.run(
+        "--test-connection", check=False, selinux_context=None
+    )
     assert test_connection.returncode == 1
 
     if _is_using_proxy(insights_client.config):

--- a/integration-tests/test_motd.py
+++ b/integration-tests/test_motd.py
@@ -71,7 +71,7 @@ def test_motd(insights_client):
         5. The MOTD file is still not present
     """
     # If the system is not registered, the file should be present.
-    insights_client.run("--status", check=False)
+    insights_client.run("--status", check=False, selinux_context=None)
     assert os.path.exists(MOTD_PATH)
 
     # After registration, the file should not exist.
@@ -113,7 +113,7 @@ def test_motd_dev_null(insights_client):
         os.symlink(os.devnull, MOTD_PATH)
         stack.callback(os.unlink, MOTD_PATH)
 
-        insights_client.run("--status", check=False)
+        insights_client.run("--status", check=False, selinux_context=None)
         assert os.path.samefile(os.devnull, MOTD_PATH)
 
         insights_client.register()

--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -42,7 +42,7 @@ def test_status_registered(external_candlepin, insights_client):
     assert conftest.loop_until(lambda: insights_client.is_registered)
     # Adding a small wait to ensure inventory is up-to-date
     sleep(5)
-    registration_status = insights_client.run("--status")
+    registration_status = insights_client.run("--status", selinux_context=None)
     if insights_client.config.legacy_upload:
         assert "Insights API confirms registration." in registration_status.stdout
     else:
@@ -82,7 +82,9 @@ def test_status_registered_only_locally(
     response = external_inventory.get(path=f"hosts?insights_id={insights_client.uuid}")
     assert response.json()["total"] == 0
 
-    registration_status = insights_client.run("--status", check=False)
+    registration_status = insights_client.run(
+        "--status", check=False, selinux_context=None
+    )
     if insights_client.core_version >= Version(3, 5, 7):
         assert "This host is registered.\n" == registration_status.stdout
         assert os.path.exists(REGISTERED_FILE)
@@ -120,7 +122,9 @@ def test_status_unregistered(external_candlepin, insights_client):
         insights_client.unregister()
     assert conftest.loop_until(lambda: not insights_client.is_registered)
 
-    registration_status = insights_client.run("--status", check=False)
+    registration_status = insights_client.run(
+        "--status", check=False, selinux_context=None
+    )
     if insights_client.config.legacy_upload:
         assert registration_status.returncode == 1
         assert (

--- a/integration-tests/test_version.py
+++ b/integration-tests/test_version.py
@@ -26,6 +26,6 @@ def test_version(insights_client):
         1. Command executes without errors
         2. Both "Client: " and "Core: " are present in the output
     """
-    proc = insights_client.run("--version")
+    proc = insights_client.run("--version", selinux_context=None)
     assert "Client: " in proc.stdout
     assert "Core: " in proc.stdout


### PR DESCRIPTION
…ests

Accommodate changes to InsightsClient.run() which now uses runcon by default to execute insights-client with insights_client_t SELinux context, matching production systemd behavior.

Updated user-invoked functionality tests to use selinux_context=None:
- test_version.py: --version command (1 call)
- test_client_options.py: --support, --validate, and unregistered --diagnosis (3 calls)
- test_connection.py: all --test-connection calls (5 calls)
- test_status.py: all --status calls (3 calls)
- test_motd.py: --status calls for MOTD testing (2 calls)
- test_collection.py: --verbose for timeout configuration testing (1 call)

Production/service functionality tests (registration, upload, compliance, data collection) retain default SELinux context to match systemd behavior.

This ensures tests properly differentiate between user-invoked commands and production service operations while maintaining comprehensive coverage of both scenarios.

Message Created by Cursor (calude-4-sonnet)

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->

---

<!-- Uncomment this when opening a pull request against 'main' branch.
This pull request should be also backported to following maintenance branches:

- `rhel-10-egg` (RHEL <= 10.1)
- `rhel-9-main` (RHEL >= 9.8)
- `rhel-9-egg` (RHEL <= 9.7)
- `rhel-8-egg` (RHEL 8)
-->

<!-- Uncomment this when opening a pull request against 'rhel-*' branch.
This pull request is a backport of: URL
-->
