### PR TITLE
chore: Remove delay from status registered test

### DIFF
--- a/integration-tests/test_status.py
+++ b/integration-tests/test_status.py
@@ -12,7 +12,6 @@ import contextlib
 import os
 import pytest
 from pytest_client_tools.util import Version
-from time import sleep
 
 pytestmark = pytest.mark.usefixtures("register_subman")
 
@@ -28,8 +27,7 @@ def test_status_registered(external_candlepin, insights_client):
     :tags: Tier 1
     :steps:
         1. Register the insights-client
-        2. Wait briefly to ensure inventory is up-to-date
-        3. Run `insights-client --status` command
+        2. Run `insights-client --status` command
     :expectedresults:
         1. The client registers successfully
         2. Wait time completes without issues
@@ -39,8 +37,7 @@ def test_status_registered(external_candlepin, insights_client):
     """
     insights_client.register()
     assert conftest.loop_until(lambda: insights_client.is_registered)
-    # Adding a small wait to ensure inventory is up-to-date
-    sleep(5)
+
     registration_status = insights_client.run("--status", selinux_context=None)
     if insights_client.config.legacy_upload:
         assert "Insights API confirms registration." in registration_status.stdout


### PR DESCRIPTION
Remove unnecessary 5-second delay. The test already uses loop_until to wait for registration, making the additional delay redundant.

---

This pull request should be also backported to following maintenance branches:

- `rhel-10-egg` (RHEL <= 10.1)
- `rhel-9-main` (RHEL >= 9.8)
- `rhel-9-egg` (RHEL <= 9.7)
- `rhel-8-egg` (RHEL 8)