### PR TITLE
fix: Do not switch context when running as unconfined_service_t

### DIFF
--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -324,7 +324,7 @@ def run_phase(phase, client, validated_eggs):
             context = selinux.context_new(selinux.getcon()[1])
             source_type = selinux.context_type_get(context)
 
-            if source_type in ("unconfined_t", "sysadm_t"):
+            if source_type in ("unconfined_t", "sysadm_t", "unconfined_service_t"):
                 # Do not transition into insights-core context if we're running
                 # in privileged context already.
                 logger.debug(f"Staying in SELinux context {source_type}")


### PR DESCRIPTION
* Card ID: CCT-1632

The logic for changing SELinux context at runtime should not apply when running as unconfined_service_t. This context is active when insights-client is run as a systemd daemon: during automatic registration, when executed via rhc-worker-playbook.

---

This pull request should be also backported to following maintenance branches:

- `rhel-10-egg` (RHEL <= 10.1)
- `rhel-9-main` (RHEL >= 9.8)
- `rhel-9-egg` (RHEL <= 9.7)