### PR TITLE
[rhel-9-main] fix: Do not switch context when running as unconfined_service_t

### DIFF
--- a/src/insights_client/__init__.py
+++ b/src/insights_client/__init__.py
@@ -324,7 +324,7 @@ def run_phase(phase, client, validated_eggs):
             context = selinux.context_new(selinux.getcon()[1])
             source_type = selinux.context_type_get(context)
 
-            if source_type in ("unconfined_t", "sysadm_t"):
+            if source_type in ("unconfined_t", "sysadm_t", "unconfined_service_t"):
                 # Do not transition into insights-core context if we're running
                 # in privileged context already.
                 logger.debug(f"Staying in SELinux context {source_type}")


### PR DESCRIPTION
* Card ID: CCT-1632

The logic for changing SELinux context at runtime should not apply when running as unconfined_service_t. This context is active when insights-client is run as a systemd daemon: during automatic registration, when executed via rhc-worker-playbook.

(cherry picked from commit 8c9f44c482a10bdc6bd12a311db815532bfbd08d)

---

This pull request is a backport of: #521 