### PR TITLE
feat: drop distro dependency

### DIFF
--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,4 +1,3 @@
 git+https://github.com/RedHatInsights/pytest-client-tools@main
 pyyaml
 pytest-subtests
-distro

--- a/integration-tests/test_compliance.py
+++ b/integration-tests/test_compliance.py
@@ -6,14 +6,29 @@
 :upstream: Yes
 """
 
+import os
 import pytest
-import distro
 from pytest_client_tools.util import loop_until
+
+
+def _system_is_rhel() -> bool:
+    """
+    Check if the OS is RHEL based on /etc/os-release file.
+    """
+    if not os.path.isfile("/etc/os-release"):
+        return False
+    with open("/etc/os-release", encoding="utf-8") as f:
+        for line in f:
+            if line.startswith("ID="):
+                os_id = line.strip().split("=")[-1].strip('"')
+                return os_id == "rhel"
+    return False
+
 
 pytestmark = [
     pytest.mark.usefixtures("register_subman"),
     pytest.mark.skipif(
-        distro.id() != "rhel",
+        not _system_is_rhel(),
         reason="Skipping tests because OS ID is not RHEL",
         allow_module_level=True,
     ),


### PR DESCRIPTION
* Card ID: CCT-1619

The distro package is a dependency for the insights-client integration test suite. To reduce the need for third-party dependencies, we decided to drop this package.

---

This pull request should be also backported to following maintenance branches:

- `rhel-10-egg` (RHEL <= 10.1)
- `rhel-9-main` (RHEL >= 9.8)
- `rhel-9-egg` (RHEL <= 9.7)
- `rhel-8-egg` (RHEL 8)

<!-- Uncomment this when opening a pull request against 'rhel-*' branch.
This pull request is a backport of: URL
-->

### Notes for the reviewer:
I reviewed the test farm, and the only test potentially affected by this change (test_compliance.py) fails with the same error as reported in issue #507 . This suggests the failure is unrelated to my changes.

While I aimed to keep the implementation stylistically close to the original distro package, I chose not to use the shlex module for parsing /etc/os-release