### PR TITLE
feat: update message of the day from Insights to Lightspeed

### DIFF
--- a/data/insights-client.motd
+++ b/data/insights-client.motd
@@ -1,9 +1,9 @@
-Register this system with Red Hat Insights: rhc connect
+Register this system with Red Hat Lightspeed: rhc connect
 
 Example:
 # rhc connect --activation-key <key> --organization <org>
 
-The rhc client and Red Hat Insights will enable analytics and additional
+The rhc client and Red Hat Lightspeed will enable analytics and additional
 management capabilities on your system.
 View your connected systems at https://console.redhat.com/insights
 

--- a/integration-tests/test_motd.py
+++ b/integration-tests/test_motd.py
@@ -143,10 +143,10 @@ def test_motd_message():
     """
     cmd = ["cat", MOTD_SRC]
     output = subprocess.check_output(cmd, universal_newlines=True)
-    motd_msg = "Register this system with Red Hat Insights: rhc connect\n\n\
+    motd_msg = "Register this system with Red Hat Lightspeed: rhc connect\n\n\
 Example:\n\
 # rhc connect --activation-key <key> --organization <org>\n\n\
-The rhc client and Red Hat Insights will enable analytics and additional\n\
+The rhc client and Red Hat Lightspeed will enable analytics and additional\n\
 management capabilities on your system.\n\
 View your connected systems at https://console.redhat.com/insights\n\n\
 You can learn more about how to register your system \n\


### PR DESCRIPTION
* Card ID: RHEL-122146

Since Insights is rebranding to Lightspeed, the message of the day initiated by insights-client should reference "Red Hat Lightspeed" instead of "Red Hat Insights".