### PR TITLE
Add fixture for checking SELinux denials in all tests

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -135,3 +135,8 @@ def check_avcs():
             "AVCs detected during test run!\n" +
             avcs.stdout.decode(),
         )
+
+@pytest.fixture(autouse=True)
+def use_selinux_permissive_mode():
+    subprocess.run(['setenforce', 'permissive'], check=True)
+    yield


### PR DESCRIPTION
Let's turn on checking AVCs in all tests.

This needs to be improved so that certain tests can suppress this check, especially those that are expected to hit AVCs as part of their scenario.