### PR TITLE
[rhel-8-egg] fix(test): correct settings download logic in integration test

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -27,10 +27,14 @@ dnf --setopt install_weak_deps=False install -y \
 # If this is an insightsCore PR build and sign the new egg.
 [ -z "${insightsCoreBranch+x}" ] || ./systemtest/insights-core-setup.sh
 
-# Override settings if provided and available.
-if [ -n "${SETTINGS_URL+x}" ] && curl -I "$SETTINGS_URL" > /dev/null 2>&1; then
-  [ -f ./settings.toml ] && mv ./settings.toml.bak
-  curl "$SETTINGS_URL" -o ./settings.toml
+# If SETTINGS_URL is set (most likely in .testing-farm.yaml), download the settings
+# file from the provided URL. Back up any existing settings.toml before downloading.
+if [[ -v SETTINGS_URL ]]; then
+  [ -f ./settings.toml ] && mv ./settings.toml ./settings.toml.bak
+  if ! curl -f "$SETTINGS_URL" -o ./settings.toml; then
+    echo "ERROR: Failed to download settings from: $SETTINGS_URL" >&2
+    exit 1
+  fi
 fi
 
 python3 -m venv venv


### PR DESCRIPTION
- Fix mv command missing target (settings.toml -> settings.toml.bak)
- Use [[ -v SETTINGS_URL ]] pattern for consistency
- Remove duplicate curl -I check, use curl -f for fail-fast behavior
- Add descriptive comments explaining SETTINGS_URL usage
- Add error handling with clear error message to stderr

Root cause: mv command was missing destination, causing test setup to fail

This pull request is a backport of: https://github.com/RedHatInsights/insights-client/pull/560