### PR TITLE
Add ability to filter pytest tests when run through TMT

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -40,7 +40,7 @@ python3 -m venv venv
 
 pip install -r integration-tests/requirements.txt
 
-pytest --log-level debug --junit-xml=./junit.xml -v integration-tests
+pytest --log-level debug --junit-xml=./junit.xml -v integration-tests ${PYTEST_FILTER:+-k ${PYTEST_FILTER}}
 retval=$?
 
 if [ -d "$TMT_PLAN_DATA" ]; then


### PR DESCRIPTION
This is useful for test development when one wants to run only a single test.

This pull request should be also backported to following maintenance branches:
- `rhel-10-egg` (RHEL <= 10.1)
- `rhel-9-main` (RHEL >= 9.8)
- `rhel-9-egg` (RHEL <= 9.7)
- `rhel-8-egg` (RHEL 8)