### PR TITLE
fix(test): Fix flaky tests that use --check-results

### DIFF
--- a/integration-tests/test_checkin.py
+++ b/integration-tests/test_checkin.py
@@ -41,8 +41,9 @@ def test_ultralight_checkin(insights_client, test_config):
         4. The updated timestamps were retrieved and recorded
         5. Both updated timestamps will be greater than before check-in
     """
-    insights_client.register()
-    assert loop_until(lambda: insights_client.is_registered)
+    assert insights_client.register(wait_for_registered=True)
+    assert insights_client.wait_for_inventory()  # required by --check-results
+    assert insights_client.wait_for_advisor()  # required by --check-results
 
     # Performing check-results operation provides latest host data in host-details.json
     insights_client.run("--check-results")

--- a/integration-tests/test_client.py
+++ b/integration-tests/test_client.py
@@ -213,8 +213,9 @@ def test_insights_details_file_exists(insights_client):
         4. The file /var/lib/insights/insights-client.json does not exists
     """
     output_file = "/var/lib/insights/insights-details.json"
-    insights_client.register()
-    assert loop_until(lambda: insights_client.is_registered)
+    insights_client.register(wait_for_registered=True)
+    assert insights_client.wait_for_inventory()  # required by --check-results
+    assert insights_client.wait_for_advisor()  # required by --check-results
 
     # Deleting file manually
     with contextlib.suppress(FileNotFoundError):

--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -292,8 +292,9 @@ def test_check_show_results(insights_client):
     """
     os.chmod("/etc/ssh/sshd_config", 0o777)
 
-    insights_client.register()
-    assert loop_until(lambda: insights_client.is_registered)
+    insights_client.register(wait_for_registered=True)
+    assert insights_client.wait_for_inventory()  # required by --check-results
+    assert insights_client.wait_for_advisor()  # required by --check-results
 
     try:
         insights_client.run("--check-results")


### PR DESCRIPTION
There seems to be a race condition in tests that use --check-result which requires system to appear both in inventory and in advisor. Otherwise the tests don't behave as expected. This PR adds active waiting for both in tests that seem to be affected by this.

* Card ID: CCT-1634

---

This pull request should be also backported to following maintenance branches:
- `rhel-10-egg` (RHEL <= 10.1)
- `rhel-9-main` (RHEL >= 9.8)
- `rhel-9-egg` (RHEL <= 9.7)
- `rhel-8-egg` (RHEL 8)