### PR TITLE
Address SELinux incompatibility of testing

### DIFF
--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -110,7 +110,12 @@ def test_group(insights_client, tmp_path):
     group_name = "testing-group"
 
     # Running insights-client in offline mode to generate archive
-    insights_client.run("--offline", f"--group={group_name}", f"--output-dir={tmp_path}")
+    insights_client.run(
+        "--offline",
+        f"--group={group_name}",
+        f"--output-dir={tmp_path}",
+        selinux_context=None,  # using --group, not a service related option
+    )
 
     with (tmp_path / "data/tags.json").open("r") as f:
         tag_file_content: dict = json.load(f)

--- a/integration-tests/test_collection.py
+++ b/integration-tests/test_collection.py
@@ -39,7 +39,10 @@ def test_output_file_valid_parameters(insights_client, tmp_path):
     archive_name = tmp_path / "archive"
 
     # Running insights-client in offline mode to generate archive
-    cmd_result = insights_client.run(f"--output-file={archive_name}")
+    cmd_result = insights_client.run(
+        f"--output-file={archive_name}",
+        selinux_context=None,  # using custom archive location, not a service related option
+    )
     assert os.path.isfile(f"{archive_name}.tar.gz")
     assert f"Collected data copied to {archive_name}.tar.gz" in cmd_result.stdout
 
@@ -180,7 +183,11 @@ def test_output_dir_with_not_empty_directory(insights_client):
         5. The error message is as expected
     """
     relative_path = os.path.realpath("")
-    cmd_result = insights_client.run(f"--output-dir={relative_path}", check=False)
+    cmd_result = insights_client.run(
+        f"--output-dir={relative_path}",
+        check=False,
+        selinux_context=None,  # using custom archive location, not a service related option
+    )
     assert cmd_result.returncode == 1
     assert f"Directory {relative_path} already exists and is not empty." in cmd_result.stderr
 

--- a/integration-tests/test_registration.py
+++ b/integration-tests/test_registration.py
@@ -265,6 +265,7 @@ def test_register_group_option(insights_client, legacy_upload_value):
         "--register",
         "--group=tag",
         check=False,
+        selinux_context=None,  # using --group, not a service related option
     )
     assert register_group_option.returncode == 0
 

--- a/integration-tests/test_ros.py
+++ b/integration-tests/test_ros.py
@@ -129,11 +129,18 @@ def test_upload_pre_collected_archive_with_ros(insights_client, tmp_path):
     assert loop_until(lambda: insights_client.is_registered)
 
     # Running insights-client in offline mode to generate archive and save at tmp dir
-    insights_client.run(f"--output-file={archive_location}")
+    insights_client.run(
+        f"--output-file={archive_location}",
+        selinux_context=None,  # using custom archive location, not a service action
+    )
 
     # Running insights-client --payload with --content-type to upload archive
     # collected in previous step
-    upload_result = insights_client.run(f"--payload={archive_location}", "--content-type=gz")
+    upload_result = insights_client.run(
+        f"--payload={archive_location}",
+        "--content-type=gz",
+        selinux_context=None,  # using custom archive location, not a service action
+    )
     assert "Uploading Insights data." in upload_result.stdout
     assert "Successfully uploaded report" in upload_result.stdout
 

--- a/integration-tests/test_upload.py
+++ b/integration-tests/test_upload.py
@@ -42,11 +42,18 @@ def test_upload_pre_collected_archive(insights_client, tmp_path):
     assert loop_until(lambda: insights_client.is_registered)
 
     # Running insights-client in offline mode to generate archive and save at tmp dir
-    insights_client.run(f"--output-file={archive_location}")
+    insights_client.run(
+        f"--output-file={archive_location}",
+        selinux_context=None,  # using custom archive location, not a service action
+    )
 
     # Running insights-client --payload with --content-type to upload archive
     # collected in previous step
-    upload_result = insights_client.run(f"--payload={archive_location}", "--content-type=gz")
+    upload_result = insights_client.run(
+        f"--payload={archive_location}",
+        "--content-type=gz",
+        selinux_context=None,  # using custom archive location, not a service action
+    )
     assert "Uploading Insights data." in upload_result.stdout
     assert "Successfully uploaded report" in upload_result.stdout
 
@@ -81,18 +88,27 @@ def test_upload_wrong_content_type(insights_client, tmp_path):
     assert loop_until(lambda: insights_client.is_registered)
 
     # Running insights-client in offline mode to generate archive and save at tmp dir
-    insights_client.run(f"--output-file={archive_location}")
+    insights_client.run(
+        f"--output-file={archive_location}",
+        selinux_context=None,  # using custom archive location, not a service action
+    )
 
     # Running insights-client --payload with invalid --content-type to upload archive
     # collected in previous step
     upload_result = insights_client.run(
-        f"--payload={archive_location}", "--content-type=bzip", check=False
+        f"--payload={archive_location}",
+        "--content-type=bzip",
+        check=False,
+        selinux_context=None,  # using custom archive location, not a service action
     )
     assert "Invalid content-type." in upload_result.stdout
 
     # trying to upload with a valid content type but different from compressor
     upload_result = insights_client.run(
-        f"--payload={archive_location}", "--content-type=xz", check=False
+        f"--payload={archive_location}",
+        "--content-type=xz",
+        check=False,
+        selinux_context=None,  # using custom archive location, not a service action
     )
     assert "Content type different from compression" in upload_result.stdout
 


### PR DESCRIPTION
Some tests were not prepared for SELinux testing. Mostly, they are testing command-line/tool related functionality rather than the "service" mode of insights-client - being invoked by system timer or by other services such as rhccc. Those test cases need to explicitly call insights-client as a user would do not setting SELinux context.

* Card ID: CCT-1867

---

This pull request should be also backported to following maintenance branches:
- `rhel-9-main` (RHEL >= 9.8)