### PR TITLE
Fix placement of "with ros" condition in specfile

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -107,7 +107,6 @@ if [ "$_SHOULD_WRITE_MOTD" -eq 1 ]; then
     ln -sn %{_sysconfdir}/insights-client/insights-client.motd %{_sysconfdir}/motd.d/insights-client
 fi
 
-%if %{with ros}
 if [ $1 -eq 2 ]; then
     /usr/sbin/semanage permissive --list | grep -q 'insights_client_t'
     if [ $? -eq 0 ]; then
@@ -115,6 +114,7 @@ if [ $1 -eq 2 ]; then
     fi
 fi
 
+%if %{with ros}
 %post ros
 rm -f /var/lib/pcp/config/pmlogger/config.ros
 sed -i "/PCP_LOG_DIR\/pmlogger\/ros/d" /etc/pcp/pmlogger/control.d/local


### PR DESCRIPTION
<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->

---

<!-- Uncomment this when opening a pull request against 'main' branch.
This pull request should be also backported to following maintenance branches:

- `rhel-10-egg` (RHEL <= 10.1)
- `rhel-9-main` (RHEL >= 9.8)
- `rhel-9-egg` (RHEL <= 9.7)
- `rhel-8-egg` (RHEL 8)
-->

<!-- Uncomment this when opening a pull request against 'rhel-*' branch.
This pull request is a backport of: URL
-->
