### PR TITLE
[rhel-9-egg] feat: building RPMs with ros subpackages

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -1,9 +1,5 @@
 %define _binaries_in_noarch_packages_terminate_build 0
 
-# This conditional build macro adds a "--with ros" commandline option to
-# rpmbuild. The default behavior is to build without it.
-%bcond_with ros
-
 Name:                   insights-client
 Summary:                Uploads Insights information to Red Hat on a periodic basis
 Version:                3.9.0
@@ -43,7 +39,6 @@ BuildRequires: systemd-rpm-macros
 %description
 Sends insightful information to Red Hat for automated analysis
 
-%if %{with ros}
 %package ros
 Requires: pcp-zeroconf
 Requires: insights-client
@@ -51,11 +46,9 @@ Requires: insights-client
 Summary: The subpackage for Insights resource optimization service
 
 %description ros
-
 The ros subpackage add ros_collect configuration parameter to insights-client.conf file,
 the parameter is set to True by default. The system starts sending PCP archives to
 Resource Optimization service upon modifying ros_collect parameter to True.
-%endif
 
 %prep
 {{{ git_dir_setup_macro }}}
@@ -93,7 +86,6 @@ if [ -d %{_sysconfdir}/motd.d ]; then
     fi
 fi
 
-%if %{with ros}
 %post ros
 rm -f /var/lib/pcp/config/pmlogger/config.ros
 sed -i "/PCP_LOG_DIR\/pmlogger\/ros/d" /etc/pcp/pmlogger/control.d/local
@@ -105,7 +97,6 @@ ros_collect=True
 ### End insights-client-ros ###
 EOF
 fi
-%endif
 
 %preun
 %systemd_preun %{name}.timer
@@ -128,10 +119,8 @@ if [ $1 -eq 0 ]; then
     rm -f %{_sysconfdir}/insights-client/.*.etag
 fi
 
-%if %{with ros}
 %postun ros
 sed -i '/### Begin insights-client-ros ###/,/### End insights-client-ros ###/d;/ros_collect=True/d' %{_sysconfdir}/insights-client/insights-client.conf
-%endif
 
 %files
 %config(noreplace) %{_sysconfdir}/insights-client/*.conf
@@ -157,9 +146,7 @@ sed -i '/### Begin insights-client-ros ###/,/### End insights-client-ros ###/d;/
 %{_mandir}/man8/*.8.gz
 %{_mandir}/man5/*.5.gz
 
-%if %{with ros}
 %files ros
-%endif
 
 %changelog
 {{{ git_dir_changelog }}}


### PR DESCRIPTION
Modified .spec file to always build additional RPM with ros subpackage.
(cherry picked from commit 3d4c9b168bfda9f6929b5902e0b9c2d913b463fe)

* Card ID: CCT-1872

---

This pull request is a backport of: #573 
