### PR TITLE
[rhel-10-egg] ci: RHEL multiarch build support in .packit.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -21,7 +21,10 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      - rhel-10
+      - rhel-10-x86_64
+      - rhel-10-aarch64
+      - rhel-10-s390x
+      - rhel-10-ppc64le
       - centos-stream-10-x86_64
       - centos-stream-10-aarch64
       - centos-stream-10-s390x
@@ -33,7 +36,10 @@ jobs:
     owner: "@yggdrasil"
     project: latest
     targets:
-      - rhel-10
+      - rhel-10-x86_64
+      - rhel-10-aarch64
+      - rhel-10-s390x
+      - rhel-10-ppc64le
       - centos-stream-10-x86_64
       - centos-stream-10-aarch64
       - centos-stream-10-s390x


### PR DESCRIPTION
Modified .packit.yaml to match multiarch support that was already available for CentOS Stream.

(cherry picked from commit 3dce7c6aec4e018ad39582937e7927265f636994)

---

* Card ID: CCT-1871

This pull request is a backport of: #575