### PR TITLE
[rhel-9-main] ci: RHEL multiarch build support in .packit.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,7 +22,10 @@ jobs:
     trigger: pull_request
     targets:
       - centos-stream-9
-      - rhel-9
+      - rhel-9-x86_64
+      - rhel-9-aarch64
+      - rhel-9-s390x
+      - rhel-9-ppc64le
 
   - job: copr_build
     trigger: commit
@@ -31,7 +34,10 @@ jobs:
     project: latest
     targets:
       - centos-stream-9
-      - rhel-9
+      - rhel-9-x86_64
+      - rhel-9-aarch64
+      - rhel-9-s390x
+      - rhel-9-ppc64le
 
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
Modified .packit.yaml to match multiarch support.

---

* Card ID: CCT-1871

This pull request is a backport of: #575