### PR TITLE
[rhel-8-egg] ci: RHEL multiarch build support in .packit.yaml

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,14 +22,18 @@ jobs:
     trigger: pull_request
     targets:
       - centos-stream-8
-      - rhel-8
+      - rhel-8-x86_64
+      - rhel-8-aarch64
+      - rhel-8-s390x
 
   - job: copr_build
     trigger: commit
     branch: rhel-8-egg
     targets:
       - centos-stream-8
-      - rhel-8
+      - rhel-8-x86_64
+      - rhel-8-aarch64
+      - rhel-8-s390x
 
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
Modified .packit.yaml to match multiarch support.

---

* Card ID: CCT-1871

This pull request is a backport of: #575