### PR TITLE
[rhel-9-egg]ci: Remove copr owner/project and test artifacts from packit config

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -26,9 +26,7 @@ jobs:
 
   - job: copr_build
     trigger: commit
-    branch: master
-    owner: "@yggdrasil"
-    project: latest
+    branch: rhel-9-egg
     targets:
       - centos-stream-9
       - rhel-9
@@ -40,11 +38,6 @@ jobs:
       - centos-stream-9
     labels:
       - unit
-    tf_extra_params:
-      environments:
-        - artifacts:
-            - type: repository-file
-              id: https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/centos-stream-$releasever/group_yggdrasil-latest-centos-stream-$releasever.repo
 
   - job: tests
     trigger: pull_request
@@ -57,10 +50,7 @@ jobs:
       - unit
     tf_extra_params:
       environments:
-        - artifacts:
-            - type: repository-file
-              id: https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/rhel-$releasever/group_yggdrasil-latest-rhel-$releasever.repo
-          settings:
+        - settings:
             provisioning:
               tags:
                 BusinessUnit: sst_csi_client_tools

--- a/systemtest/guest-setup.sh
+++ b/systemtest/guest-setup.sh
@@ -1,22 +1,4 @@
 #!/usr/bin/bash
 # this is a general use version of the guest setup that happens in testing farm
 
-# check for insights-client from existing repos
-if ! dnf info insights-client &>/dev/null; then
-  source <(cat /etc/os-release | grep ^ID)
-  
-  # convert os-release to copr name
-  if [ "$ID" == "centos" ]; then
-    DISTRO='centos-stream'
-  else
-    DISTRO="$ID"
-  fi
-
-  # have to pull from dnf as os-release does not follow the same format on rhel
-  RELEASEVER=$(python3 -c 'import dnf, json; db = dnf.dnf.Base(); print(db.conf.substitutions["releasever"])')
-
-  curl https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/$DISTRO-$RELEASEVER/group_yggdrasil-latest-$DISTRO-$RELEASEVER.repo \
-    -o /etc/yum.repos.d/yggdrasil.repo
-fi
-
 dnf -y install insights-client


### PR DESCRIPTION
Remove copr owner/project and test artifacts from packit config

I have removed owner and project specification from commit-triggered copr_build job, removed repository-file artifacts from unit test jobs (centos-stream and rhel) and cleaned up tf_extra_params configuration in test jobs. I have also removed yggdrasil copr repository setup from guest-setup.sh script.

(cherry picked from commit edfc8c4cf047377dd2534ddec22997a8a30da05a)

* Card ID: CCT-1673


---

<!-- Uncomment this when opening a pull request against 'main' branch.
This pull request should be also backported to following maintenance branches:

- `rhel-10-egg` (RHEL <= 10.1)
- `rhel-9-main` (RHEL >= 9.8)
- `rhel-9-egg` (RHEL <= 9.7)
- `rhel-8-egg` (RHEL 8)
-->

<!-- Uncomment this when opening a pull request against 'rhel-*' branch.
This pull request is a backport of: URL
-->
