### PR TITLE
[rhel-9-main] Add ability to filter pytest tests when run through TMT

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -40,7 +40,7 @@ python3 -m venv venv
 
 pip install -r integration-tests/requirements.txt
 
-pytest --log-level debug --junit-xml=./junit.xml -v integration-tests ${PYTEST_FILTER:+-k ${PYTEST_FILTER}}
+pytest --log-level debug --junit-xml=./junit.xml -v integration-tests ${PYTEST_FILTER:+-k "${PYTEST_FILTER}"}
 retval=$?
 
 if [ -d "$TMT_PLAN_DATA" ]; then


### PR DESCRIPTION
This pull request is a backport of:

- https://github.com/RedHatInsights/insights-client/pull/568
- https://github.com/RedHatInsights/insights-client/pull/581