### PR TITLE
[rhel-9-egg] fix: remove rhel-9-ppc64le from multiarch build

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,7 +25,6 @@ jobs:
       - rhel-9-x86_64
       - rhel-9-aarch64
       - rhel-9-s390x
-      - rhel-9-ppc64le
 
   - job: copr_build
     trigger: commit
@@ -35,7 +34,6 @@ jobs:
       - rhel-9-x86_64
       - rhel-9-aarch64
       - rhel-9-s390x
-      - rhel-9-ppc64le
 
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
* Modified .packit.yaml to remove rhel-9-ppc64le because it is not built by packit (it is not in copr chroot list).
