### PR TITLE
fix: Failure to remove missing rpm.egg files

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -81,9 +81,7 @@ mkdir -p %{buildroot}%{_localstatedir}/cache/insights-client/
 %systemd_post %{name}.timer
 %systemd_post %{name}-boot.service
 
-# Remove legacy egg files from previous installations
-rm -f %{_sysconfdir}/insights-client/rpm.egg
-rm -f %{_sysconfdir}/insights-client/rpm.egg.asc
+# Remove legacy egg files from previous runtime installations
 rm -f %{_localstatedir}/lib/insights/*.egg
 rm -f %{_localstatedir}/lib/insights/*.egg.asc
 


### PR DESCRIPTION
* Removed redundant rm commands from the %post script. These commands were deleting files that the RPM update handles automatically (because the old RPM owned those files), resulting in unnecessary file removal warnings during updates.

* Card ID: CCT-1802

This pull request should be also backported to following maintenance branches:
- `rhel-9-main` (RHEL >= 9.8)