### PR TITLE
[rhel-9-main] test: Check that egg related content is not present on the system

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -96,6 +96,27 @@ allow insights_core_t user_devpts_t:chr_file { ioctl read write };
     subprocess.run(["semodule", "-r", "core_output"], check=True)
 
 
+@pytest.fixture(scope="session", autouse=True)
+def check_no_egg_content():
+    """
+    Check that there is no egg-based content on the system.
+    """
+    egg_based_directory = "/var/lib/insights/"
+    egg_based_files = [
+        "/etc/insights-client/redhattools.pub.gpg",
+        "/etc/insights-client/rpm.egg",
+        "/etc/insights-client/rpm.egg.asc",
+        "/etc/insights-client/.insights-core.etag",
+        "/etc/insights-client/.insights-core-gpg-sig.etag",
+    ]
+
+    if os.listdir(egg_based_directory):
+        pytest.fail(f"Directory {egg_based_directory} should be empty.")
+    for file_path in egg_based_files:
+        if os.path.exists(file_path):
+            pytest.fail(f"File {file_path} should not exist on the system.")
+
+
 def check_is_bootc_system():
     """
     Check if the system is a bootc enabled system.


### PR DESCRIPTION
* Card ID: CCT-1858

To make sure that egg related content is no longer used and is not brought in to the system by the insights-client, the universal check was needed for the tests. This commit implements check that the directory /var/lib/insights is empty and files related to egg-based insights-core are not present on the system.

(cherry picked from commit d2f59aedf14611a1aee0a1f213ce1707d90c8089)

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->

---

This pull request is a backport of: #603 