### PR TITLE
[rhel-9-main] fix: Failure to remove missing rpm.egg files

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -83,9 +83,7 @@ mkdir -p %{buildroot}%{_localstatedir}/cache/insights-client/
 %systemd_post %{name}.timer
 %systemd_post %{name}-boot.service
 
-# Remove legacy egg files from previous installations
-rm -f %{_sysconfdir}/insights-client/rpm.egg
-rm -f %{_sysconfdir}/insights-client/rpm.egg.asc
+# Remove legacy egg files from previous runtime installations
 rm -f %{_localstatedir}/lib/insights/*.egg
 rm -f %{_localstatedir}/lib/insights/*.egg.asc
 


### PR DESCRIPTION
* Card ID: CCT-1803

* Removed redundant rm commands from the %post script. These commands were deleting files that the RPM transaction handles automatically, resulting in unnecessary file removal warnings during updates.

(cherry picked from commit 8f97cfe6603b2a302d6cc35b1b06dc11e8f3fbed)

---

This pull request is a backport of: #602 
