### PR TITLE
[rhel-9-main] Drop unused runtime requirement on setuptools (distutils)

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -22,7 +22,6 @@ Requires: python3-requests >= 2.6
 Requires: python3-PyYAML
 Requires: python3-magic
 Requires: python3-six
-Requires: python3dist(setuptools)
 Requires: coreutils
 Requires: ((selinux-policy >= 38.1.68-1) if selinux-policy)
 Requires: (python3-libselinux if selinux-policy)

--- a/src/insights_client/tests/requirements.txt
+++ b/src/insights_client/tests/requirements.txt
@@ -1,5 +1,2 @@
 pytest
-# Setuptools is required because we still rely on 'distutils' which have been dropped in Python 3.12.
-# setuptools package ships it vendorized as a top-level package, so for a time being we can rely on it.
-setuptools
 -r requirements-core.txt


### PR DESCRIPTION
* Card ID: CCT-357

The dependency was removed in 7ee71029904c92456605c383be95e62e6db9dea2.

(cherry picked from commit b4ee7b0753500ab26353b553cdf6432eb5f4f9ec)

---

This pull request is a backport of: #397 