### PR TITLE
ci: Fix flake8 filename pattern

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 filename =
     *.py,
     *.py.in,
-    */src/insights-client.in,
+    */src/insights-client,
 # same limit as black
 max-line-length = 100
 ignore =


### PR DESCRIPTION
Remove .in extension from insights-client filename pattern in flake8 configuration to match the actual file structure.

---