### PR TITLE
[rhel-8-egg] feat(test): add check for timer status

### DIFF
--- a/integration-tests/test_registration.py
+++ b/integration-tests/test_registration.py
@@ -9,10 +9,40 @@
 import os
 import pytest
 import contextlib
+import subprocess
 from pytest_client_tools.util import Version, loop_until
 from constants import MACHINE_ID_FILE
 
 pytestmark = pytest.mark.usefixtures("register_subman")
+
+
+def assert_systemd_insights_client_timer_enabled_and_active():
+    """
+    Ensure the systemd timer for insights-client is enabled, active and scheduled.
+    """
+    result = subprocess.run(
+        [
+            "systemctl",
+            "show",
+            "insights-client.timer",
+            "--property=UnitFileState,ActiveState,NextElapseUSecRealtime",
+        ],
+        stdout=subprocess.PIPE,
+        universal_newlines=True,
+        check=True,
+    )
+
+    systemd_timer_properties = dict(line.split("=", 1) for line in result.stdout.splitlines())
+
+    # 1. enabled
+    assert systemd_timer_properties["UnitFileState"] == "enabled"
+
+    # 2. active
+    assert systemd_timer_properties["ActiveState"] == "active"
+
+    # 3. scheduled (systemd sometimes uses "infinity" when not scheduled)
+    next_elapse = systemd_timer_properties["NextElapseUSecRealtime"]
+    assert next_elapse and next_elapse != "infinity"
 
 
 @pytest.mark.tier1
@@ -29,17 +59,20 @@ def test_register(insights_client):
         1. Run insights-client with --register option
         2. Verify the client successfully registered
         3. Verify the report is successfully uploaded
+        4. Verify the insights-client.timer is enabled and active
     :expectedresults:
         1. The client attempts to register
         2. The client is confirmed as registered and the output includes
             "Starting to collect Insights data."
         3. The output includes "Successfully uploaded report"
+        4. The insights-client.timer is enabled and active
     """
     register_result = insights_client.run("--register")
     assert loop_until(lambda: insights_client.is_registered)
 
     assert "Starting to collect Insights data" in register_result.stdout
     assert "Successfully uploaded report" in register_result.stdout
+    assert_systemd_insights_client_timer_enabled_and_active()
 
 
 @pytest.mark.tier1
@@ -56,11 +89,13 @@ def test_register_auth_proxy(insights_client, test_config):
         1. Set the proxy configuration in the insights-client.conf file
         2. Run the insights-client with --register option and verbose output
         3. Verify the client is successfully registered
+        4. Verify the insights-client.timer is enabled and active
     :expectedresults:
         1. The proxy details are saved to the client config file
         2. The client attempts to register, using the configured proxy
         3. The client is confirmed as registered and the output includes
             the proxy details (host,user) and 'Proxy Scheme'
+        4. The insights-client.timer is enabled and active
     """
     try:
         proxy_host = test_config.get("auth_proxy", "host")
@@ -81,6 +116,7 @@ def test_register_auth_proxy(insights_client, test_config):
     assert "Proxy Scheme: http://" in register_result.stdout
     assert f"Proxy Location: {proxy_host}" in register_result.stdout
     assert f"Proxy User: {proxy_user}" in register_result.stdout
+    assert_systemd_insights_client_timer_enabled_and_active()
 
 
 @pytest.mark.tier1
@@ -97,11 +133,13 @@ def test_register_noauth_proxy(insights_client, test_config):
         1. Set the proxy configuration in the insights-client.conf file
         2. Run the insights-client with --register option and verbose output
         3. Verify the client is successfully registered
+        4. Verify the insights-client.timer is enabled and active
     :expectedresults:
         1. The proxy details are saved to the client config file
         2. The client attempts to register, using the configured proxy
         3. The client is confirmed as registered and the output includes
             'CONF Proxy' and the unauthenticated proxy details
+        4. The insights-client.timer is enabled and active
     """
     try:
         proxy_host = test_config.get("noauth_proxy", "host")
@@ -115,6 +153,7 @@ def test_register_noauth_proxy(insights_client, test_config):
     register_result = insights_client.run("--register", "--verbose")
     assert loop_until(lambda: insights_client.is_registered)
     assert f"CONF Proxy: {no_auth_proxy}" in register_result.stdout
+    assert_systemd_insights_client_timer_enabled_and_active()
 
 
 @pytest.mark.tier1
@@ -131,13 +170,15 @@ def test_machineid_exists_only_when_registered(insights_client):
         1. Verify the client is not registered and machine ID does not exist
         2. Run the insights-client without registration
         3. Register insights-client and check machine ID
-        4. Unregister insights-client and confirm machine ID is removed
+        4. Verify the insights-client.timer is enabled and active
+        5. Unregister insights-client and confirm machine ID is removed
     :expectedresults:
         1. The client is not registered and machine ID does not exist
         2. The command fails with instructions to register in output and
             machine ID still does not exist
         3. Client is successfully registered and machine ID is present on the system
-        4. The client is successfully unregistered and machine ID file is removed
+        4. The insights-client.timer is enabled and active
+        5. The client is successfully unregistered and machine ID file is removed
     """
     assert loop_until(lambda: not insights_client.is_registered)
     assert not os.path.exists(MACHINE_ID_FILE)
@@ -153,6 +194,7 @@ def test_machineid_exists_only_when_registered(insights_client):
     insights_client.register()
     assert loop_until(lambda: insights_client.is_registered)
     assert os.path.exists(MACHINE_ID_FILE)
+    assert_systemd_insights_client_timer_enabled_and_active()
 
     insights_client.unregister()
     assert not os.path.exists(MACHINE_ID_FILE)
@@ -170,18 +212,23 @@ def test_machineid_changes_on_new_registration(insights_client):
     :tags: Tier 1
     :steps:
         1. Register insights-client and store current machine ID
-        2. Unregister the client
-        3. Register client again and check the machine ID
+        2. Verify the insights-client.timer is enabled and active
+        3. Unregister the client
+        4. Register client again and check the machine ID
+        5. Verify the insights-client.timer is enabled and active
     :expectedresults:
         1. Client is registered and machine ID stored
-        2. Client successfully unregisters and machine is removed
-        3. After the registration on systems with version 3.3.16 and higher
+        2. The insights-client.timer is enabled and active
+        3. Client successfully unregisters and machine is removed
+        4. After the registration on systems with version 3.3.16 and higher
             the machine ID should stay the same, on lower versions the number
             should change
+        5. The insights-client.timer is enabled and active
     """
     insights_client.register()
     with open(MACHINE_ID_FILE, "r") as f:
         machine_id_old = f.read()
+    assert_systemd_insights_client_timer_enabled_and_active()
 
     insights_client.unregister()
     assert not os.path.exists(MACHINE_ID_FILE)
@@ -189,6 +236,7 @@ def test_machineid_changes_on_new_registration(insights_client):
     insights_client.register()
     with open(MACHINE_ID_FILE, "r") as f:
         machine_id_new = f.read()
+    assert_systemd_insights_client_timer_enabled_and_active()
 
     if insights_client.core_version >= Version(3, 3, 16):
         """after the new changes to CCT-161 machine-id stays the same"""
@@ -209,13 +257,17 @@ def test_double_registration(insights_client):
     :tags: Tier 1
     :steps:
         1. Register insights-client and store its machine ID
-        2. Run the --register command again on the registered system
-        3. Verify the machine ID remains unchanged
+        2. Verify the insights-client.timer is enabled and active
+        3. Run the --register command again on the registered system
+        4. Verify the machine ID remains unchanged
+        5. Verify the insights-client.timer is enabled and active
     :expectedresults:
         1. System is registered and machine ID is present
-        2. The command does not fail and shows a message
+        2. The insights-client.timer is enabled and active
+        3. The command does not fail and shows a message
             'This host has already been registered'
-        3. The machine ID stayed unchanged
+        4. The machine ID stayed unchanged
+        5. The insights-client.timer is enabled and active
     """
     assert loop_until(lambda: not insights_client.is_registered)
 
@@ -223,6 +275,7 @@ def test_double_registration(insights_client):
     assert os.path.exists(MACHINE_ID_FILE)
     with open(MACHINE_ID_FILE, "r") as f:
         machine_id_old = f.read()
+    assert_systemd_insights_client_timer_enabled_and_active()
 
     res = insights_client.register()
     assert "This host has already been registered" in res.stdout
@@ -231,6 +284,7 @@ def test_double_registration(insights_client):
         machine_id_new = f.read()
 
     assert machine_id_new == machine_id_old
+    assert_systemd_insights_client_timer_enabled_and_active()
 
 
 @pytest.mark.parametrize(
@@ -255,11 +309,13 @@ def test_register_group_option(insights_client, legacy_upload_value):
         1. Unregister the client if registered
         2. Set the legacy_upload value and save the configuration
         3. Run insights-client with --register and --group=tag options
+        4. Verify the insights-client.timer is enabled and active
     :expectedresults:
         1. Client is unregistered successfully
         2. The configuration is updated successfully
         3. The client is registered with the specified group and the return
             code is 0
+        4. The insights-client.timer is enabled and active
     """
     # make sure the system is not registered to insights
     with contextlib.suppress(Exception):
@@ -273,6 +329,7 @@ def test_register_group_option(insights_client, legacy_upload_value):
         check=False,
     )
     assert register_group_option.returncode == 0
+    assert_systemd_insights_client_timer_enabled_and_active()
 
 
 @pytest.mark.tier1
@@ -290,13 +347,15 @@ def test_registered_and_unregistered_files_are_created_and_deleted(insights_clie
         1. Verify that the client is not registered and .registered file does not exist
         2. Register the client and verify that the .registered file was created
             and .unregistered does not appear
-        3. Unregister the client and verify that .registered file was removed and
+        3. Verify the insights-client.timer is enabled and active
+        4. Unregister the client and verify that .registered file was removed and
             .unregistered file was created
     :expectedresults:
         1. Client is not registered and .registered file does not exist
         2. The client registers and .registered file is created, .unregistered
             does not exist
-        3. The client is unregistered, .registered file was removed and .unregistered
+        3. The insights-client.timer is enabled and active
+        4. The client is unregistered, .registered file was removed and .unregistered
             appears
     """
     assert loop_until(lambda: not insights_client.is_registered)
@@ -306,6 +365,7 @@ def test_registered_and_unregistered_files_are_created_and_deleted(insights_clie
     assert loop_until(lambda: insights_client.is_registered)
     assert os.path.exists("/etc/insights-client/.registered")
     assert not os.path.exists("/etc/insights-client/.unregistered")
+    assert_systemd_insights_client_timer_enabled_and_active()
 
     insights_client.unregister()
     assert os.path.exists("/etc/insights-client/.unregistered")


### PR DESCRIPTION
* Added timer check after registration. This check is needed to ensure that the automated check-in is triggered.

* Card ID: CCT-1964

---

This pull request is a backport of: #618 

---

Notes for reviewer:
I also changed `text=true` to `universal_newlines=True` because there is no `text` argument in pytohn 3.6
