### PR TITLE
fix: Trying a Satellite hotfix

### DIFF
--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -1,3 +1,3 @@
-git+https://github.com/RedHatInsights/pytest-client-tools@main
+git+https://github.com/RedHatInsights/pytest-client-tools@95eb97049e06e628667fe462941c1e3fc074b597
 pyyaml
 pytest-subtests


### PR DESCRIPTION
This PR is to see if my hotfix in client-tools repo worked for integration tests run on Satellite.

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->

---

<!-- Uncomment this when opening a pull request against 'main' branch.
This pull request should be also backported to following maintenance branches:

- `rhel-10-egg` (RHEL <= 10.1)
- `rhel-9-main` (RHEL >= 9.8)
- `rhel-9-egg` (RHEL <= 9.7)
- `rhel-8-egg` (RHEL 8)
-->

<!-- Uncomment this when opening a pull request against 'rhel-*' branch.
This pull request is a backport of: URL
-->
