### PR TITLE
fix(test): Check for egg content after test completion

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -101,6 +101,7 @@ def check_no_egg_content():
     """
     Check that there is no egg-based content on the system.
     """
+    yield
     egg_based_directory = "/var/lib/insights/"
     allowed_files = [
         "private-keys-v1.d",


### PR DESCRIPTION
Move egg content check to run after test execution by converting check_no_egg_content to a generator fixture with yield. This ensures we verify no egg-based content remains in `/var/lib/insights` and in `/etc/insights-client` after the test has completed.

---

This pull request should be also backported to following maintenance branches:

- `rhel-9-main` (RHEL >= 9.8)