### PR TITLE
fix: Updating test_set_ansible_host_info to wait for Inventory

### DIFF
--- a/integration-tests/test_client_options.py
+++ b/integration-tests/test_client_options.py
@@ -40,8 +40,8 @@ def test_set_ansible_host_info(insights_client, test_config):
     if "satellite614" in test_config.environment or "satellite615" in test_config.environment:
         pytest.skip(reason="Issue was fixed in Satellite 6.16 and upwards")
     # Register system against Satellite, and register insights through satellite
-    insights_client.register()
-    assert loop_until(lambda: insights_client.is_registered)
+    insights_client.register(wait_for_registered=True)
+    assert insights_client.wait_for_inventory()
 
     # Update ansible-host
     ret = insights_client.run("--ansible-host=foo.example.com", check=False)


### PR DESCRIPTION
The test_set_ansible_host_info sometimes fails due to the system not being found in Inventory and therefore is not able to update ansible-host. I have added the option to wait for the system being registered and wait_for_inventory. This should make the test more reliable.

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->

---


This pull request should be also backported to following maintenance branches:

- `rhel-10-egg` (RHEL <= 10.1)
- `rhel-9-main` (RHEL >= 9.8)
- `rhel-9-egg` (RHEL <= 9.7)
- `rhel-8-egg` (RHEL 8)


<!-- Uncomment this when opening a pull request against 'rhel-*' branch.
This pull request is a backport of: URL
-->
