### PR TITLE
[rhel-10-egg] ci: test against RHEL-10.0 content

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -25,10 +25,6 @@ jobs:
       - rhel-10-aarch64
       - rhel-10-s390x
       - rhel-10-ppc64le
-      - centos-stream-10-x86_64
-      - centos-stream-10-aarch64
-      - centos-stream-10-s390x
-      - centos-stream-10-ppc64le
 
   - job: copr_build
     trigger: commit
@@ -38,18 +34,6 @@ jobs:
       - rhel-10-aarch64
       - rhel-10-s390x
       - rhel-10-ppc64le
-      - centos-stream-10-x86_64
-      - centos-stream-10-aarch64
-      - centos-stream-10-s390x
-      - centos-stream-10-ppc64le
-
-  - job: tests
-    trigger: pull_request
-    identifier: "unit/centos-stream"
-    targets:
-      - centos-stream-10-x86_64
-    labels:
-      - unit
 
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
* Copr builds are no longer tested in CentOS Stream
* Copr builds are tested against RHEL-10.0 content

* CardID: CCT-1983

---

This pull request should be also backported to following maintenance branches:

- `rhel-9-egg` (RHEL <= 9.7)
