### PR TITLE
chore: bump black from 24.3.0

### DIFF
--- a/.github/workflows/stylish.yml
+++ b/.github/workflows/stylish.yml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: psf/black@stable
       with:
-        version: "24.3.0"
+        options: "--check --verbose"
 
     - name: Setup flake8 annotations
       uses: rbialon/flake8-annotations@v1

--- a/integration-tests/playbook_verifier/test_verifier.py
+++ b/integration-tests/playbook_verifier/test_verifier.py
@@ -12,7 +12,6 @@ import sys
 import pytest
 from pytest_client_tools.util import Version
 
-
 PLAYBOOK_DIRECTORY = pathlib.Path(__file__).parent.absolute() / "playbooks"
 
 

--- a/integration-tests/test_display_name_option.py
+++ b/integration-tests/test_display_name_option.py
@@ -147,7 +147,7 @@ def test_register_twice_with_different_display_name(insights_client, test_config
         assert unique_hostname == record["display_name"]
         insights_id = record["insights_id"]
 
-    (status, host_details, record) = (None, None, None)
+    status, host_details, record = (None, None, None)
     with subtests.test(msg="The second registration"):
         status = insights_client.run("--register", "--display-name", unique_hostname_02)
         registration_message = "This host has already been registered"

--- a/integration-tests/test_motd.py
+++ b/integration-tests/test_motd.py
@@ -12,7 +12,6 @@ import subprocess
 import pytest
 from pytest_client_tools.util import loop_until
 
-
 DOT_REGISTERED_PATH = "/etc/insights-client/.registered"
 DOT_UNREGISTERED_PATH = "/etc/insights-client/.unregistered"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,2 @@
-# the version of black is specified also in the stylish.yml github workflow;
-# please update the version there in case it is bumped here
-black==24.3.0
+black
 flake8


### PR DESCRIPTION
Addresses https://github.com/RedHatInsights/insights-client/pull/652 

We are apparently not very good with managing Black versions. The simplest way to ensure we are kept up to date is to stop pinning the version.

insights-client codebase is small enough, we shouldn't be hitting any weird formatting issues as new minor versions are releases.