### PR TITLE
feat(ci): add image-mode/bootc test support via TMT native builder

### DIFF
--- a/integration-tests/selinux.py
+++ b/integration-tests/selinux.py
@@ -148,21 +148,29 @@ class SELinuxAVCChecker:
         self.avc_skiplist.append(condition)
         return condition
 
+    _SEPARATOR = "=" * 63
+
     def get_avcs(self, skiplisted=True):
-        lines = (
-            subprocess.run(self.aureport_command, stdout=subprocess.PIPE)
-            .stdout.decode()
-            .splitlines()
-        )
-        assert lines.pop(0) == ""
-        assert lines.pop(0) == "AVC Report"
-        assert lines.pop(0) == "==============================================================="
-        keys = lines.pop(0).split()
-        assert lines.pop(0) == "==============================================================="
-        if lines[0] == "<no events of interest were found>":
+        output = subprocess.run(self.aureport_command, stdout=subprocess.PIPE).stdout.decode()
+        lines = [line for line in output.splitlines() if line.strip()]
+
+        if not lines or "<no events of interest were found>" in output:
             return
-        for line in lines:
-            if not line:  # skip empty lines
+
+        # Find the column-header line: it sits between two separator rows.
+        keys = None
+        data_start = None
+        for i, line in enumerate(lines):
+            if line.startswith("===") and i + 2 < len(lines) and lines[i + 2].startswith("==="):
+                keys = lines[i + 1].split()
+                data_start = i + 3
+                break
+
+        if keys is None or data_start is None:
+            return
+
+        for line in lines[data_start:]:
+            if line.startswith("===") or not line.strip():
                 continue
             entry = AuditLogEntry(keys, line.split())
             if skiplisted and any(condition(entry) for condition in self.avc_skiplist):

--- a/systemtest/guest-setup.sh
+++ b/systemtest/guest-setup.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/bash
 # this is a general use version of the guest setup that happens in testing farm
 
+# check for insights-client from existing repos
+if ! dnf info insights-client &>/dev/null; then
+  source <(cat /etc/os-release | grep ^ID)
+
+  # convert os-release to copr name
+  if [ "$ID" == "centos" ]; then
+    DISTRO='centos-stream'
+  else
+    DISTRO="$ID"
+  fi
+
+  # have to pull from dnf as os-release does not follow the same format on rhel
+  RELEASEVER=$(python3 -c 'import dnf, json; db = dnf.dnf.Base(); print(db.conf.substitutions["releasever"])')
+
+  curl https://copr.fedorainfracloud.org/coprs/g/yggdrasil/latest/repo/$DISTRO-$RELEASEVER/group_yggdrasil-latest-$DISTRO-$RELEASEVER.repo \
+    -o /etc/yum.repos.d/yggdrasil.repo
+fi
+
 dnf -y install insights-client

--- a/systemtest/install-test-deps.sh
+++ b/systemtest/install-test-deps.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -ux
+
+dnf --setopt install_weak_deps=False install -y \
+  bzip2 \
+  bzip2-devel \
+  git-core \
+  insights-client \
+  logrotate \
+  man-db \
+  openscap \
+  openscap-scanner \
+  podman \
+  python3-pip \
+  python3-pytest \
+  scap-security-guide \
+  zip

--- a/systemtest/plans/main.fmf
+++ b/systemtest/plans/main.fmf
@@ -1,23 +1,12 @@
 summary: insights-client test suite
-discover:
-  how: fmf
 
 prepare:
-  - name: "Install test deps"
-    how: install
-    package:
-      - bzip2
-      - bzip2-devel
-      - git-core
-      - logrotate
-      - man-db
-      - openscap
-      - openscap-scanner
-      - podman
-      - python3-pip
-      - python3-pytest
-      - scap-security-guide
-      - zip
+  - name: install test dependencies
+    how: shell
+    script: ./systemtest/install-test-deps.sh
+
+discover:
+  how: fmf
 
 execute:
   how: tmt

--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -1,37 +1,31 @@
 #!/bin/bash
-set -u
-set -x
+set -ux
 
 # get to project root
 cd ../../../
 
-# Check for bootc/image-mode deployments which should not run dnf
-if ! command -v bootc >/dev/null || bootc status | grep -q 'System is not deployed via bootc'; then
+is_bootc() {
+  command -v bootc > /dev/null &&
+    ! bootc status --format=humanreadable | grep -q 'System is not deployed via bootc'
+}
+
+if ! is_bootc; then
   # TEST_RPMS is set in jenkins jobs after parsing CI Messages in gating Jobs.
   # If TEST_RPMS is set then install the RPM builds for gating.
   if [[ -v TEST_RPMS ]]; then
     echo "Installing RPMs: ${TEST_RPMS}"
-    dnf -y install --allowerasing ${TEST_RPMS} || { echo "REQUESTED insights-client PACKAGE IS NOT INSTALLED"; exit 2; }
+    dnf -y install --allowerasing ${TEST_RPMS}
   fi
 
   # Simulate the packit setup on downstream builds.
   # This is for ad-hoc and compose testing.
-  rpm -q insights-client > /dev/null || ./systemtest/guest-setup.sh
-
-  # In most cases these should already be installed by tmt, see systemtest/plans/main.fmf
-  dnf --setopt install_weak_deps=False install -y \
-    podman git-core python3-pip python3-pytest logrotate bzip2 zip \
-    scap-security-guide openscap-scanner openscap bzip2-devel
+  rpm -q insights-client || ./systemtest/guest-setup.sh
 fi
 
-# If SETTINGS_URL is set (most likely in .testing-farm.yaml), download the settings
-# file from the provided URL. Back up any existing settings.toml before downloading.
-if [[ -v SETTINGS_URL ]]; then
+# Override settings if provided and available.
+if [ -n "${SETTINGS_URL+x}" ] && curl -I "$SETTINGS_URL" > /dev/null 2>&1; then
   [ -f ./settings.toml ] && mv ./settings.toml ./settings.toml.bak
-  if ! curl -f "$SETTINGS_URL" -o ./settings.toml; then
-    echo "ERROR: Failed to download settings from: $SETTINGS_URL" >&2
-    exit 1
-  fi
+  curl "$SETTINGS_URL" -o ./settings.toml
 fi
 
 python3 -m venv venv
@@ -40,15 +34,14 @@ python3 -m venv venv
 
 pip install -r integration-tests/requirements.txt
 
-# Print versions of packages that are actively being tested
-rpm -q insights-client insights-core selinux-policy || true
-
 pytest --log-level debug --junit-xml=./junit.xml -v integration-tests ${PYTEST_FILTER:+-k "${PYTEST_FILTER}"}
 retval=$?
 
 if [ -d "$TMT_PLAN_DATA" ]; then
   cp ./junit.xml "$TMT_PLAN_DATA/junit.xml"
-  cp -r ./artifacts "$TMT_PLAN_DATA/"
+  if [ -d ./artifacts ]; then
+    cp -r ./artifacts "$TMT_PLAN_DATA/"
+  fi
 fi
 
 exit $retval


### PR DESCRIPTION
## Summary

Add image-mode (bootc) test infrastructure for insights-client by leveraging
TMT 1.68+'s native bootc builder support. TMT automatically detects image-mode
systems, wraps shell prepare scripts into Containerfile RUN commands, builds the
image with podman, runs `bootc switch`, and manages the reboot -- no custom
bootc logic needed in our CI scripts.

- Add `systemtest/install-test-deps.sh` as a shell prepare step so TMT can wrap
  it into a Containerfile for bootc builds (replaces the inline `install` prepare
  which TMT cannot wrap)
- Refactor `systemtest/plans/main.fmf` to use `how: shell` prepare instead of
  `how: install` (required for TMT bootc builder compatibility)
- Add `is_bootc()` guard in `test.sh` to skip `dnf install` and `guest-setup.sh`
  on image-mode systems (deps are baked into the image)
- Enhance `guest-setup.sh` with copr fallback for environments where
  `insights-client` is not in the default repos
- Clean up error handling and settings download logic in `test.sh`

Verified on `RHEL-10.2-image-mode` compose via Testing Farm: prepare phase
completes cleanly, no reboot loops.

```
testing-farm request \
  --compose RHEL-10.2-image-mode \
  --git-url https://github.com/RedHatInsights/insights-client \
  --git-ref jmolet/imagemode \
  -e SETTINGS_URL=http://auto-services.usersys.redhat.com/automation-properties/settings.toml \
  -e ENV_FOR_DYNACONF='prod' \
```
Ref: CCT-2148