### PR TITLE
fix: Remove .etag files during upgrade process

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -82,6 +82,7 @@ make install-files \
 # Remove legacy egg files from previous runtime installations
 rm -f %{_localstatedir}/lib/insights/*.egg
 rm -f %{_localstatedir}/lib/insights/*.egg.asc
+rm -f %{_sysconfdir}/insights-client/.*.etag
 
 # Symlink the message of the day if the system has not been registered with Insights
 _SHOULD_WRITE_MOTD=1


### PR DESCRIPTION
* Card ID: RHEL-145160

Since insights-core is already shipped as an RPM, .etag files (which were created by insights-core egg) should not be present in /etc/insights-client.

---

This pull request should be also backported to following maintenance branches:

- `rhel-9-main` (RHEL >= 9.8)