### PR TITLE
[rhel-9-egg] fix(test): report universal checks as FAIL

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -9,6 +9,25 @@ from pytest_client_tools.util import loop_until
 logger = logging.getLogger(__name__)
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """
+    Reclassify check_* fixture "teardown"/"setup" failures as FAIL (instead of ERROR) by
+    setting the test execution phase to "call" instead of "setup"/"teardown".
+    """
+    outcome = yield
+    rep = outcome.get_result()
+    if call.when == "call" or not call.excinfo:
+        return
+    if not isinstance(call.excinfo.value, pytest.fail.Exception):
+        return
+
+    for entry in call.excinfo.traceback:
+        if getattr(entry, "name", "").startswith("check_"):
+            rep.when = "call"
+            return
+
+
 @pytest.fixture(scope="session")
 def install_katello_rpm(test_config):
     if "satellite" in test_config.environment:


### PR DESCRIPTION
* CardID: CCT-1999

Pytest reports fixture setup and teardown failures as ERROR by default.
Add a pytest hook that detects pytest.fail() raised from universal check
fixtures and reports them as test FAIL instead.

Universal check fixtures are identified by fixture function names
starting with check_.

(cherry picked from commit ef457ae5a65fed9d352d2c3c342538e4e2877dcd)

---

This pull request is a backport of: #660 