### PR TITLE
fix(readme): update location of PEM file for symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Follow these instructions to prepare your system for development.
  
    ```shell
    $ sudo mkdir -p /etc/insights-client
-   $ sudo ln -s `pwd`/data/cert-api.access.redhat.com.pem /etc/insights-client/
+   $ sudo ln -s `pwd`/data/etc/cert-api.access.redhat.com.pem /etc/insights-client/
    ```
 
    Then you can install the package using pip:


### PR DESCRIPTION
Fix PEM file symlink location in the README.md
