### PR TITLE
[rhel-8-egg] fix(test): Printing EGG version before tests

### DIFF
--- a/systemtest/tests/integration/test.sh
+++ b/systemtest/tests/integration/test.sh
@@ -44,7 +44,8 @@ python3 -m venv venv
 pip install -r integration-tests/requirements.txt
 
 # Print versions of packages that are actively being tested
-rpm -q insights-client insights-core selinux-policy || true
+rpm -q insights-client selinux-policy || true
+insights-client --version
 
 pytest --log-level debug --junit-xml=./junit.xml -v integration-tests ${PYTEST_FILTER:+-k "${PYTEST_FILTER}"}
 retval=$?


### PR DESCRIPTION
As we do not need insights-core on RHEL version where EGGs are being used I have removed the insights-core from the rpm command and added insights-client version printing to show the egg version. This change will help mainly with testing the EGG from insights-core team.

(cherry picked from commit 768c6072653427381cdcd0e109df103e3200e5a9)

<!--
* Card ID: RHEL-xxxx
* Card ID: CCT-xxxx
-->

---

<!-- Uncomment this when opening a pull request against 'main' branch.
This pull request should be also backported to following maintenance branches:

- `rhel-10-egg` (RHEL <= 10.1)
- `rhel-9-main` (RHEL >= 9.8)
- `rhel-9-egg` (RHEL <= 9.7)
- `rhel-8-egg` (RHEL 8)
-->

<!-- Uncomment this when opening a pull request against 'rhel-*' branch.
This pull request is a backport of: URL
-->
