### PR TITLE
ci: add dependabot config for rhel-9-main branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
     target-branch: "main"
     commit-message:
       prefix: "ci"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "rhel-9-main"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
Configure weekly GitHub Actions dependency updates targeting the rhel-9-main branch to keep CI actions up-to-date across maintenance branches.

---