### PR TITLE
fix(test): Handle aarch64 AVC syscall

### DIFF
--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -192,14 +192,18 @@ def add_known_avcs_to_skiplist(avc_checker):
             "obj": "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023",
         }
     )  # Bug: https://issues.redhat.com/browse/CCT-2009
-    avc_checker.skip_avc_entry_by_fields(
-        {
-            "subj": "system_u:system_r:insights_client_t:s0",
-            "syscall": "fstat",
-            "permission": "getattr",
-            "obj": "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023",
-        }
-    )  # Bug: https://issues.redhat.com/browse/CCT-2009
+
+    # aarch64 uses newfstat
+    for syscall in ("fstat", "newfstat"):
+        avc_checker.skip_avc_entry_by_fields(
+            {
+                "subj": "system_u:system_r:insights_client_t:s0",
+                "syscall": syscall,
+                "permission": "getattr",
+                "obj": "unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023",
+            }
+        )  # Bug: https://issues.redhat.com/browse/CCT-2009
+
     avc_checker.skip_avc_entry_by_fields(
         {
             "subj": "system_u:system_r:rhsmcertd_t:s0",


### PR DESCRIPTION
The known CCT-2009 getattr denial is reported as fstat on x86_64 but as newfstat on aarch64. Skip both syscall variants for the same known SELinux AVC pattern.

* Card ID: CCT-2555

---

This pull request should be also backported to following maintenance branches:

- `rhel-9-main` (RHEL >= 9.8)