### PR TITLE
[rhel-9-main] fix: Update tmpfile.d conf file to include required insights-client directories

### DIFF
--- a/data/tmpfiles.d/insights-client.conf
+++ b/data/tmpfiles.d/insights-client.conf
@@ -1,1 +1,6 @@
+d /var/lib/insights         0750 root root -
+d /var/log/insights-client  0700 root root -
+d /var/cache/insights       0750 root root -
+d /var/cache/insights-client  0700 root root -
+
 R /var/tmp/insights-client* - - - 24h


### PR DESCRIPTION
* Card ID: CCT-2061

- Update insights-client tmpfiles.d configuration to include the required directories for insights-client and ensure existence for bootc image build.
