### PR TITLE
[rhel-10-egg] chore: remove unused EGG_VERSION reference from egg upgrade script

### DIFF
--- a/scripts/01-upgrade-egg.sh
+++ b/scripts/01-upgrade-egg.sh
@@ -16,7 +16,5 @@ for PROGRAM in "${PROGRAMS[@]}"; do
     fi
 done
 
-TAG=$(cat EGG_VERSION)
-
 curl --fail -L https://console.redhat.com/api/v1/static/release/insights-core.el10.egg --output data/rpm.egg
 curl --fail -L https://console.redhat.com/api/v1/static/release/insights-core.el10.egg.asc --output data/rpm.egg.asc

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,3 @@
 ## 01-upgrade-egg.sh
 
-This script downloads the egg and the uploader.json (and the ones that are signed) that is defined in `EGG_VERSION` file.
+This script downloads the egg and its signature from console.redhat.com.


### PR DESCRIPTION
The `EGG_VERSION` file is no longer used; the egg is downloaded directly from console.redhat.com. Update README accordingly.