### PR TITLE
[rhel-9-egg] docs: update egg download description in scripts README

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,3 @@
 ## 01-upgrade-egg.sh
 
-This script downloads the egg and the uploader.json (and the ones that are signed) that is defined in `EGG_VERSION` file.
+This script downloads the egg and its signature from console.redhat.com.


### PR DESCRIPTION
Egg upgrade script doesn't use `EGG_VERSION` file and `uploader.json` anymore, README file should be updated accordingly.