### PR TITLE
[rhel-10-egg] chore: clean up logrotate file after uninstallation

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -117,6 +117,7 @@ if [ $1 -eq 0 ]; then
     rm -rf %{_localstatedir}/lib/insights
     rm -rf %{_localstatedir}/log/insights-client
     rm -f %{_sysconfdir}/insights-client/.*.etag
+    rm -f %{_sysconfdir}/logrotate.d/insights-client
 fi
 
 %postun ros


### PR DESCRIPTION
During uninstallation process of insights-client in downstream, the logrotate file for insights-client is removed. Upstream spec file should do the same thing.

---

This pull request should be also backported to following maintenance branches:

- `rhel-9-egg` (RHEL <= 9.7)
- `rhel-8-egg` (RHEL 8)