### PR TITLE
[rhel-8-egg] chore: clean up logrotate file after uninstallation

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -94,6 +94,7 @@ if [ $1 -eq 0 ]; then
     rm -rf %{_localstatedir}/lib/insights
     rm -rf %{_localstatedir}/log/insights-client
     rm -f %{_sysconfdir}/insights-client/.*.etag
+    rm -f %{_sysconfdir}/logrotate.d/insights-client
 fi
 
 %files


### PR DESCRIPTION
During uninstallation process of insights-client in downstream, the logrotate file for insights-client is removed. Upstream spec file should do the same thing.


(cherry picked from commit 142466d723e880e24ed65e3fb3f3cd36c5188fa8)

---

This pull request is a backport of: #687 