### PR TITLE
[rhel-9-main] fix: Mark runtime directories as %ghost in spec file

### DIFF
--- a/insights-client.spec
+++ b/insights-client.spec
@@ -79,6 +79,8 @@ make install-files \
 %systemd_post %{name}.timer
 %systemd_post %{name}-boot.service
 
+%tmpfiles_create insights-client.conf
+
 # Remove legacy egg files from previous runtime installations
 rm -f %{_localstatedir}/lib/insights/*.egg
 rm -f %{_localstatedir}/lib/insights/*.egg.asc
@@ -155,10 +157,10 @@ rm -rf %{buildroot}
 %{python3_sitelib}/insights_client/
 %{_defaultdocdir}/%{name}
 %{_presetdir}/*.preset
-%attr(700,root,root) %dir %{_localstatedir}/log/insights-client/
-%attr(700,root,root) %dir %{_localstatedir}/cache/insights-client/
-%attr(750,root,root) %dir %{_localstatedir}/cache/insights/
-%attr(750,root,root) %dir %{_localstatedir}/lib/insights/
+%ghost %attr(700,root,root) %dir %{_localstatedir}/log/insights-client/
+%ghost %attr(700,root,root) %dir %{_localstatedir}/cache/insights-client/
+%ghost %attr(750,root,root) %dir %{_localstatedir}/cache/insights/
+%ghost %attr(750,root,root) %dir %{_localstatedir}/lib/insights/
 %{_sysconfdir}/logrotate.d/insights-client
 %{_tmpfilesdir}/insights-client.conf
 


### PR DESCRIPTION
* Card ID: RHEL-135034

Directories managed by tmpfiles.d are marked as %ghost so RPM does not warn about missing files when the package is removed after the directories have already been cleaned up.

(cherry picked from commit cae148616bb647f11547b4b32c026305d70ac19b)

---

This pull request is a backport of: #691